### PR TITLE
feat(db/common): off zstd compression

### DIFF
--- a/pkg/db/common/util/util.go
+++ b/pkg/db/common/util/util.go
@@ -4,46 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 
-	"github.com/klauspost/compress/zstd"
 	"github.com/pkg/errors"
 )
 
-func Marshal(v any, compress bool) ([]byte, error) {
+func Marshal(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	je := json.NewEncoder(&buf)
 	je.SetEscapeHTML(false)
 	if err := je.Encode(v); err != nil {
 		return nil, errors.Wrap(err, "json encode")
 	}
-
-	if compress {
-		zw, err := zstd.NewWriter(nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "new zstd writer")
-		}
-		return zw.EncodeAll(buf.Bytes(), make([]byte, 0, buf.Len())), nil
-	}
 	return buf.Bytes(), nil
 }
 
-func Unmarshal(data []byte, compress bool, v any) error {
-	if compress {
-		zr, err := zstd.NewReader(bytes.NewReader(data))
-		if err != nil {
-			return errors.Wrap(err, "new zstd reader")
-		}
-		defer zr.Close()
-
-		if err := json.NewDecoder(zr).Decode(v); err != nil {
-			return errors.Wrap(err, "json decode")
-		}
-
-		return nil
-	}
-
+func Unmarshal(data []byte, v any) error {
 	if err := json.Unmarshal(data, v); err != nil {
 		return errors.Wrap(err, "json unmarshal")
 	}
-
 	return nil
 }


### PR DESCRIPTION
## before
```console
$ vuls db init --dbpath ~/.cache/vuls/vuls-zstd.db
2024/07/24 16:58:37 INFO Delete All Data
2024/07/24 16:58:37 INFO Put Metadata

$ /usr/bin/time -v ./vuls db add --dbpath ~/.cache/vuls/vuls-zstd.db ~/.cache/vuls-data-update/extracted/vuls-data-extracted-amazon
2024/07/24 16:58:46 INFO Get Metadata
2024/07/24 16:58:46 INFO Put Vulnerability Data
2024/07/24 17:01:42 INFO Put DataSource
2024/07/24 17:01:42 INFO Put Metadata
	Command being timed: "./vuls db add --dbpath /home/mainek00n/.cache/vuls/vuls-zstd.db /home/mainek00n/.cache/vuls-data-update/extracted/vuls-data-extracted-amazon"
	User time (seconds): 931.38
	System time (seconds): 61.17
	Percent of CPU this job got: 565%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:55.66
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 449820
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 16647045
	Voluntary context switches: 821746
	Involuntary context switches: 177170
	Swaps: 0
	File system inputs: 0
	File system outputs: 506816
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

$ zstd --ultra -22 -T8 ~/.cache/vuls/vuls-zstd.db -o ~/.cache/vuls/vuls-zstd.db.zst
/home/mainek00n/.cache/vuls/vuls-zstd.db :  3.69%   (142675968 => 5265073 bytes, /home/mainek00n/.cache/vuls/vuls-zstd.db.zst)
```

## after
```console
$ vuls db init --dbpath ~/.cache/vuls/vuls-no-zstd.db
2024/07/24 16:56:18 INFO Delete All Data
2024/07/24 16:56:18 INFO Put Metadata

$ /usr/bin/time -v ./vuls db add --dbpath ~/.cache/vuls/vuls-no-zstd.db ~/.cache/vuls-data-update/extracted/vuls-data-extracted-amazon
2024/07/24 16:56:37 INFO Get Metadata
2024/07/24 16:56:37 INFO Put Vulnerability Data
2024/07/24 16:56:59 INFO Put DataSource
2024/07/24 16:56:59 INFO Put Metadata
	Command being timed: "./vuls db add --dbpath /home/mainek00n/.cache/vuls/vuls-no-zstd.db /home/mainek00n/.cache/vuls-data-update/extracted/vuls-data-extracted-amazon"
	User time (seconds): 3.98
	System time (seconds): 1.32
	Percent of CPU this job got: 23%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:22.70
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 421744
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 105891
	Voluntary context switches: 71380
	Involuntary context switches: 10227
	Swaps: 0
	File system inputs: 0
	File system outputs: 570600
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

$ zstd --ultra -22 -T8 ~/.cache/vuls/vuls-no-zstd.db -o ~/.cache/vuls/vuls-no-zstd.db.zst
/home/mainek00n/.cache/vuls/vuls-no-zstd.db :  1.00%   (173375488 => 1732210 bytes, /home/mainek00n/.cache/vuls/vuls-no-zstd.db.zst)
```