### PR TITLE
fix(db/boltdb): consolidate tiny txs

### DIFF
--- a/pkg/db/common/boltdb/boltdb.go
+++ b/pkg/db/common/boltdb/boltdb.go
@@ -514,8 +514,8 @@ func (c *Connection) getVulnerabilityData(root vulnerabilityRoot) (*types.Vulner
 }
 
 func (c *Connection) PutVulnerabilityData(root string) error {
-	roots := map[string]dbTypes.VulnerabilityRoot{}
 	if err := c.conn.Update(func(tx *bolt.Tx) error {
+		roots := map[string]dbTypes.VulnerabilityRoot{}
 		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err

--- a/pkg/db/common/boltdb/boltdb.go
+++ b/pkg/db/common/boltdb/boltdb.go
@@ -741,9 +741,9 @@ func putRoot(tx *bolt.Tx, root dbTypes.VulnerabilityRoot) error {
 		return errors.Errorf("bucket:%q is not exists", "vulnerability")
 	}
 
-	vrb := vb.Bucket([]byte("root"))
-	if vrb == nil {
-		return nil
+	vrb, err := vb.CreateBucketIfNotExists([]byte("root"))
+	if err != nil {
+		return errors.Wrapf(err, "create bucket:%q if not exists", "vulnerability:root")
 	}
 
 	if bs := vrb.Get([]byte(root.ID)); len(bs) > 0 {

--- a/pkg/db/common/boltdb/boltdb.go
+++ b/pkg/db/common/boltdb/boltdb.go
@@ -753,12 +753,12 @@ func putRoot(tx *bolt.Tx, root dbTypes.VulnerabilityRoot) error {
 		}
 		for _, a := range r.Advisories {
 			if !slices.Contains(root.Advisories, a) {
-				r.Advisories = append(r.Advisories, a)
+				root.Advisories = append(root.Advisories, a)
 			}
 		}
 		for _, v := range r.Vulnerabilities {
 			if !slices.Contains(root.Vulnerabilities, v) {
-				r.Vulnerabilities = append(r.Vulnerabilities, v)
+				root.Vulnerabilities = append(root.Vulnerabilities, v)
 			}
 		}
 		for _, d := range r.DataSources {


### PR DESCRIPTION
This PR is about performance improvement of "db add".

Before: 46 sec
```
% rm -f ./vuls.lo.db;  time ./vuls db init --dbpath ./vuls.lo.db
2024/07/25 20:56:18 INFO Delete All Data
2024/07/25 20:56:18 INFO Put Metadata
./vuls db init --dbpath ./vuls.lo.db  0.00s user 0.01s system 20% cpu 0.048 total
% /usr/bin/time -v ./vuls.lo.7292763 db add ~/extracted/vuls-data-extracted-amazon --dbpath ./vuls.lo.db
2024/07/25 20:56:27 INFO Get Metadata
2024/07/25 20:56:27 INFO Put Vulnerability Data
2024/07/25 20:57:12 INFO Put DataSource
2024/07/25 20:57:12 INFO Put Metadata
        Command being timed: "./vuls.lo.7292763 db add /home/shino/extracted/vuls-data-extracted-amazon --dbpath ./vuls.lo.db"
        User time (seconds): 4.35
        System time (seconds): 1.74
        Percent of CPU this job got: 13%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:45.93
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 471584
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 177
        Minor (reclaiming a frame) page faults: 119089
        Voluntary context switches: 119267
        Involuntary context switches: 63
        Swaps: 0
        File system inputs: 31752
        File system outputs: 570304
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

After: 3 sec
```
% rm -f ./vuls.lo.db;  time ./vuls db init --dbpath ./vuls.lo.db
2024/07/25 20:56:00 INFO Delete All Data
2024/07/25 20:56:00 INFO Put Metadata
./vuls db init --dbpath ./vuls.lo.db  0.00s user 0.01s system 18% cpu 0.046 total
% /usr/bin/time -v ./vuls.lo.no-tiny-txs db add ~/extracted/vuls-data-extracted-amazon --dbpath ./vuls.lo.db
2024/07/25 20:56:02 INFO Get Metadata
2024/07/25 20:56:02 INFO Put Vulnerability Data
2024/07/25 20:56:04 INFO Put DataSource
2024/07/25 20:56:04 INFO Put Metadata
        Command being timed: "./vuls.lo.no-tiny-txs db add /home/shino/extracted/vuls-data-extracted-amazon --dbpath ./vuls.lo.db"
        User time (seconds): 3.27
        System time (seconds): 0.34
        Percent of CPU this job got: 125%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.87
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 369180
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 92583
        Voluntary context switches: 2469
        Involuntary context switches: 68
        Swaps: 0
        File system inputs: 8
        File system outputs: 305872
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```