### PR TITLE
fix(db/fetch): use temporary file while writing then rename

### DIFF
--- a/pkg/db/fetch/fetch.go
+++ b/pkg/db/fetch/fetch.go
@@ -199,7 +199,7 @@ func (o *options) write(d *zstd.Decoder) error {
 	defer pb.Close()
 
 	if _, err := d.WriteTo(io.MultiWriter(f, pb)); err != nil {
-		return errors.Wrapf(err, "write to %s", o.dbpath)
+		return errors.Wrapf(err, "write to %s", tmpPath)
 	}
 
 	if err := os.Rename(tmpPath, o.dbpath); err != nil {


### PR DESCRIPTION
If any errors occur while writing db file and the db file remains halfway, next attempt to open file will fails.
This PR uses temporary file while writing to db file and rename it to actual db file after write finished.

This PR does NOT use tmp file (e.g. somethins under /tmp/). This is because /tmp may be different partitions than the actural db file. In such case, full read of tmp file and full write to actual db file is needed, and there is a chance of half finished db file too.
