### PR TITLE
feat(version): fill version when using go install

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,9 @@
 package version
 
-import "fmt"
+import (
+	"fmt"
+	"runtime/debug"
+)
 
 var (
 	Version  string
@@ -8,5 +11,13 @@ var (
 )
 
 func String() string {
-	return fmt.Sprintf("vuls %s %s", Version, Revision)
+	if Version != "" && Revision != "" {
+		return fmt.Sprintf("vuls %s %s", Version, Revision)
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return fmt.Sprintf("vuls %s", info.Main.Version)
+	}
+
+	return fmt.Sprintf("vuls %s", "(unknown)")
 }


### PR DESCRIPTION
When you install vuls with go install, the version and revision are not embedded. Therefore, it is unclear which version of vuls was used, and in particular, the metadata of the vuls db is lacking.
```console
$ bbolt get ~/.cache/vuls/vuls.db "metadata" "db" | jq .created_by
"vuls  "
```

## before
```console
$ go install github.com/MaineK00n/vuls2/cmd/vuls@nightly
$ vuls version
vuls
```
## after
```console
$ go install github.com/MaineK00n/vuls2/cmd/vuls@1fb98420
$ vuls version
vuls v0.0.1-alpha.0.20250117001826-1fb984203a3e
```