### PR TITLE
fix(db/fetch): support proxy

### DIFF
--- a/pkg/cmd/db/fetch/fetch.go
+++ b/pkg/cmd/db/fetch/fetch.go
@@ -15,11 +15,13 @@ func NewCmd() *cobra.Command {
 	options := struct {
 		dbpath     string
 		repository string
+		proxy      string
 		noProgress bool
 		debug      bool
 	}{
 		dbpath:     filepath.Join(utilos.UserCacheDir(), "vuls.db"),
 		repository: "ghcr.io/mainek00n/vuls2:latest",
+		proxy:      "",
 		noProgress: false,
 		debug:      false,
 	}
@@ -32,7 +34,7 @@ func NewCmd() *cobra.Command {
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if err := db.Fetch(db.WithDBPath(options.dbpath), db.WithRepository(options.repository), db.WithNoProgress(options.noProgress), db.WithDebug(options.debug)); err != nil {
+			if err := db.Fetch(db.WithDBPath(options.dbpath), db.WithRepository(options.repository), db.WithProxy(options.proxy), db.WithNoProgress(options.noProgress), db.WithDebug(options.debug)); err != nil {
 				return errors.Wrap(err, "db fetch")
 			}
 			return nil
@@ -41,6 +43,7 @@ func NewCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&options.dbpath, "dbpath", "", options.dbpath, "vuls db path")
 	cmd.Flags().StringVarP(&options.repository, "repository", "", options.repository, "vuls db repository")
+	cmd.Flags().StringVarP(&options.proxy, "proxy", "", options.proxy, "http proxy")
 	cmd.Flags().BoolVarP(&options.noProgress, "no-progress", "", options.noProgress, "no progress bar")
 	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
 


### PR DESCRIPTION
```console
$ vuls db fetch --repository ghcr.io/vulsio/vuls-nightly-db:nightly
2025/01/22 09:58:23 INFO Fetch vuls.db repository=ghcr.io/vulsio/vuls-nightly-db:nightly
failed to exec vuls: failed to resolve nightly: Get "https://ghcr.io/v2/vulsio/vuls-nightly-db/manifests/nightly": dial tcp: lookup ghcr.io on 127.0.0.11:53: server misbehaving
...

$ vuls db fetch --repository ghcr.io/vulsio/vuls-nightly-db:nightly --proxy http://squid:3128
2025/01/22 09:58:31 INFO Fetch vuls.db repository=ghcr.io/vulsio/vuls-nightly-db:nightly
⠙ fetching (320 MB, 147 MB/s) [2s]
```

NOTE: environment variables are already supported
```console
$ HTTPS_PROXY=http://squid:3128 vuls db fetch --repository ghcr.io/vulsio/vuls-nightly-db:nightly
2025/01/22 11:00:30 INFO Fetch vuls.db repository=ghcr.io/vulsio/vuls-nightly-db:nightly
⠙ fetching (320 MB, 149 MB/s) [2s]
```