### PR TITLE
fix(db/redis): fix db search of redis

### DIFF
--- a/pkg/db/common/redis/redis.go
+++ b/pkg/db/common/redis/redis.go
@@ -887,50 +887,44 @@ func (c *Connection) removeVulnerabilityDataCommands(ctx context.Context, source
 }
 
 func (c *Connection) GetRoot(id dataTypes.RootID) (*dbTypes.VulnerabilityData, error) {
-	bs, err := c.conn.Do(context.TODO(), c.conn.B().Get().Key(fmt.Sprintf("vulnerability#root#%s", id)).Build()).AsBytes()
+	m, err := c.conn.Do(context.TODO(), c.conn.B().Hgetall().Key(fmt.Sprintf("vulnerability#root#%s", id)).Build()).AsMap()
 	if err != nil {
 		if rueidis.IsRedisNil(err) {
 			return nil, errors.Wrapf(dbTypes.ErrNotFoundRoot, "vulnerability#root#%s not found", id)
 		}
-		return nil, errors.Wrapf(err, "GET %s", fmt.Sprintf("vulnerability#root#%s", id))
+		return nil, errors.Wrapf(err, "HGETALL %s", fmt.Sprintf("vulnerability#root#%s", id))
 	}
 
-	var r vulnerabilityRoot
-	if err := util.Unmarshal(bs, &r); err != nil {
-		return nil, errors.Wrapf(err, "unmarshal %s", fmt.Sprintf("vulnerability#root#%s", id))
+	d := dbTypes.VulnerabilityData{
+		ID: string(id),
 	}
 
-	return &dbTypes.VulnerabilityData{
-		ID: string(r.ID),
-		Advisories: func() []dbTypes.VulnerabilityDataAdvisory {
-			as := make([]dbTypes.VulnerabilityDataAdvisory, 0, len(r.Advisories))
-			for _, a := range r.Advisories {
-				as = append(as, dbTypes.VulnerabilityDataAdvisory{ID: a})
-			}
-			return as
-		}(),
-		Vulnerabilities: func() []dbTypes.VulnerabilityDataVulnerability {
-			vs := make([]dbTypes.VulnerabilityDataVulnerability, 0, len(r.Vulnerabilities))
-			for _, v := range r.Vulnerabilities {
-				vs = append(vs, dbTypes.VulnerabilityDataVulnerability{ID: v})
-			}
-			return vs
-		}(),
-		Detections: func() []dbTypes.VulnerabilityDataDetection {
-			ds := make([]dbTypes.VulnerabilityDataDetection, 0, len(r.Ecosystems))
-			for _, e := range r.Ecosystems {
-				ds = append(ds, dbTypes.VulnerabilityDataDetection{Ecosystem: e})
-			}
-			return ds
-		}(),
-		DataSources: func() []datasourceTypes.DataSource {
-			ds := make([]datasourceTypes.DataSource, 0, len(r.DataSources))
-			for _, d := range r.DataSources {
-				ds = append(ds, datasourceTypes.DataSource{ID: d})
-			}
-			return ds
-		}(),
-	}, nil
+	for sid, v := range m {
+		bs, err := v.AsBytes()
+		if err != nil {
+			return nil, errors.Wrapf(err, "as bytes. key: %s, field: %s", fmt.Sprintf("vulnerability#root#%s", id), sid)
+		}
+
+		var r vulnerabilityRoot
+		if err := util.Unmarshal(bs, &r); err != nil {
+			return nil, errors.Wrapf(err, "unmarshal %s", fmt.Sprintf("%s -> %s", fmt.Sprintf("vulnerability#root#%s", id), sid))
+		}
+
+		for _, a := range r.Advisories {
+			d.Advisories = append(d.Advisories, dbTypes.VulnerabilityDataAdvisory{ID: a})
+		}
+		for _, v := range r.Vulnerabilities {
+			d.Vulnerabilities = append(d.Vulnerabilities, dbTypes.VulnerabilityDataVulnerability{ID: v})
+		}
+		for _, e := range r.Ecosystems {
+			d.Detections = append(d.Detections, dbTypes.VulnerabilityDataDetection{Ecosystem: e})
+		}
+		for _, ds := range r.DataSources {
+			d.DataSources = append(d.DataSources, datasourceTypes.DataSource{ID: ds})
+		}
+	}
+
+	return &d, nil
 }
 
 func (c *Connection) GetAdvisory(id advisoryContentTypes.AdvisoryID) (map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory, error) {


### PR DESCRIPTION
Preparation:

```
[0]% docker run --rm --name redis -d -p 127.0.0.1:6379:6379 redis
06b436ab16c54170f8f280f45704bb5784acbe27e6f5703f218d069350c011bd
[0]% go run ./cmd/vuls db init --dbtype redis --dbpath redis://127.0.0.1:6379
2025/12/15 18:15:41 INFO Delete All Data
2025/12/15 18:15:41 INFO Initialize DB
2025/12/15 18:15:41 INFO Put Metadata
[0]% go run ./cmd/vuls db add --dbtype redis --dbpath redis://127.0.0.1:6379 ~/dotgit/vuls-data-extracted-alma-errata/
2025/12/15 18:15:43 INFO Get Metadata
2025/12/15 18:15:43 INFO Put DataSource
2025/12/15 18:15:43 INFO Put Vulnerability Data
2025/12/15 18:15:45 INFO Put Metadata
```

Before:

```
[0]% go run ./cmd/vuls db search advisory ALSA-2019:3708 --dbtype redis --dbpath redis://127.0.0.1:6379 | jq .
2025/12/15 18:17:54 INFO Get Metadata
2025/12/15 18:17:54 INFO Get Vulnerability Data queries=[ALSA-2019:3708]
failed to exec vuls: WRONGTYPE Operation against a key holding the wrong kind of value
GET vulnerability#root#ALSA-2019:3708
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetRoot
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:895
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1.2
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:206
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:271
github.com/MaineK00n/vuls2/pkg/db/search.Search
        /home/shino/g/vuls2/pkg/db/search/search.go:130
github.com/MaineK00n/vuls2/pkg/cmd/db/search.newAdvisoryCmd.func1
        /home/shino/g/vuls2/pkg/cmd/db/search/search.go:89
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.main
        /home/shino/g/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
get root
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1.2
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:211
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:271
github.com/MaineK00n/vuls2/pkg/db/search.Search
        /home/shino/g/vuls2/pkg/db/search/search.go:130
github.com/MaineK00n/vuls2/pkg/cmd/db/search.newAdvisoryCmd.func1
        /home/shino/g/vuls2/pkg/cmd/db/search/search.go:89
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.main
        /home/shino/g/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
get vulnerability data by advisory id: ALSA-2019:3708
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:276
github.com/MaineK00n/vuls2/pkg/db/search.Search
        /home/shino/g/vuls2/pkg/db/search/search.go:130
github.com/MaineK00n/vuls2/pkg/cmd/db/search.newAdvisoryCmd.func1
        /home/shino/g/vuls2/pkg/cmd/db/search/search.go:89
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.main
        /home/shino/g/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
get vulnerability data
github.com/MaineK00n/vuls2/pkg/db/search.Search-range1
        /home/shino/g/vuls2/pkg/db/search/search.go:132
github.com/MaineK00n/vuls2/pkg/db/common/redis.(*Connection).GetVulnerabilityData.func1
        /home/shino/g/vuls2/pkg/db/common/redis/redis.go:276
github.com/MaineK00n/vuls2/pkg/db/search.Search
        /home/shino/g/vuls2/pkg/db/search/search.go:130
github.com/MaineK00n/vuls2/pkg/cmd/db/search.newAdvisoryCmd.func1
        /home/shino/g/vuls2/pkg/cmd/db/search/search.go:89
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.main
        /home/shino/g/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
db search
github.com/MaineK00n/vuls2/pkg/cmd/db/search.newAdvisoryCmd.func1
        /home/shino/g/vuls2/pkg/cmd/db/search/search.go:90
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.1/command.go:1071
main.main
        /home/shino/g/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
exit status 1
```

After: (full JSON output is at https://gist.github.com/shino/782f6ff4f3fe9b83ffe50c94f717f805)
```
[0]% go run ./cmd/vuls db search advisory ALSA-2019:3708 --dbtype redis --dbpath redis://127.0.0.1:6379 | jq -M .
2025/12/15 18:19:05 INFO Get Metadata
2025/12/15 18:19:05 INFO Get Vulnerability Data queries=[ALSA-2019:3708]
{
  "id": "ALSA-2019:3708",
  "advisories": [
    {
      "id": "ALSA-2019:3708",
      "contents": {
        "alma-errata": {
          "ALSA-2019:3708": [
[snip]
```


