### PR TITLE
fix(pkg/detect): no index is not an error in detection

### DIFF
--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -29,7 +29,7 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, queries []str
 	for _, q := range queries {
 		rs, err := s.GetIndex(ecosystem, q)
 		if err != nil {
-			if errors.Is(err, dbTypes.ErrNotFoundEcosystem) || errors.Is(err, dbTypes.ErrNotFoundIndex) {
+			if errors.Is(err, dbTypes.ErrNotFoundIndex) {
 				continue
 			}
 


### PR DESCRIPTION
Before:

```
[0]% go run cmd/vuls/main.go detect -d --results-dir ./res2.lo
2026/01/14 18:09:22 INFO Get Metadata
2026/01/14 18:09:22 INFO Detect ServerUUID=7dea2bc0-78e3-4831-a9a3-de3bce9fb4cd scanned=2025-09-29T19:38:53.000+09:00
failed to exec vuls: index not found
github.com/MaineK00n/vuls2/pkg/db/session/types.init
        <autogenerated>:1
runtime.doInit1
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:7670
runtime.doInit
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:7637
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:256
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
"alpine:3.19 -> index -> libssl3" not found
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.(*Connection).GetIndex.func1
        /home/shino/g/fix-detect/vuls2/pkg/db/session/internal/boltdb/boltdb.go:608
go.etcd.io/bbolt.(*DB).View
        /home/shino/go/pkg/mod/go.etcd.io/bbolt@v1.4.3/db.go:939
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.(*Connection).GetIndex
        /home/shino/g/fix-detect/vuls2/pkg/db/session/internal/boltdb/boltdb.go:595
github.com/MaineK00n/vuls2/pkg/detect/util.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/util/detect.go:29
github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/ospkg/ospkg.go:70
github.com/MaineK00n/vuls2/pkg/detect.detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:220
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:192
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
github.com/MaineK00n/vuls2/pkg/db/session/internal/boltdb.(*Connection).GetIndex
        /home/shino/g/fix-detect/vuls2/pkg/db/session/internal/boltdb/boltdb.go:617
github.com/MaineK00n/vuls2/pkg/detect/util.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/util/detect.go:29
github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/ospkg/ospkg.go:70
github.com/MaineK00n/vuls2/pkg/detect.detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:220
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:192
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
get index
github.com/MaineK00n/vuls2/pkg/detect/util.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/util/detect.go:31
github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/ospkg/ospkg.go:70
github.com/MaineK00n/vuls2/pkg/detect.detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:220
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:192
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
detect
github.com/MaineK00n/vuls2/pkg/detect/ospkg.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/ospkg/ospkg.go:91
github.com/MaineK00n/vuls2/pkg/detect.detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:220
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:192
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
detect os packages
github.com/MaineK00n/vuls2/pkg/detect.detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:222
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:192
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
detect 7dea2bc0-78e3-4831-a9a3-de3bce9fb4cd
github.com/MaineK00n/vuls2/pkg/detect.Detect.func1
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:194
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:208
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
github.com/MaineK00n/vuls2/pkg/detect.Detect
        /home/shino/g/fix-detect/vuls2/pkg/detect/detect.go:209
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:35
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
detect
github.com/MaineK00n/vuls2/pkg/cmd/detect.NewCmd.func1
        /home/shino/g/fix-detect/vuls2/pkg/cmd/detect/detect.go:36
github.com/spf13/cobra.(*Command).execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1015
github.com/spf13/cobra.(*Command).ExecuteC
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148
github.com/spf13/cobra.(*Command).Execute
        /home/shino/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071
main.main
        /home/shino/g/fix-detect/vuls2/cmd/vuls/main.go:11
runtime.main
        /home/shino/sdk/go1.25.4/src/runtime/proc.go:285
runtime.goexit
        /home/shino/sdk/go1.25.4/src/runtime/asm_amd64.s:1693
exit status 1
```

After:
```
[0]% go run cmd/vuls/main.go detect -d --results-dir ./res2.lo
2026/01/14 18:10:12 INFO Get Metadata
2026/01/14 18:10:12 INFO Detect ServerUUID=7dea2bc0-78e3-4831-a9a3-de3bce9fb4cd scanned=2025-09-29T19:38:53.000+09:00
[0]% 
```