### PR TITLE
chore(detect/ospkg): efficient rename

### DIFF
--- a/pkg/detect/ospkg/ospkg.go
+++ b/pkg/detect/ospkg/ospkg.go
@@ -253,8 +253,14 @@ func convertVCQueryPackage(family ecosystemTypes.Ecosystem, p scanTypes.OSPackag
 func rename(family ecosystemTypes.Ecosystem, name string) string {
 	switch family {
 	case ecosystemTypes.EcosystemTypeDebian:
+		if !strings.HasPrefix(name, "linux-") {
+			return name
+		}
 		return strings.NewReplacer("linux-signed", "linux", "linux-latest", "linux", "-amd64", "", "-arm64", "", "-i386", "").Replace(name)
 	case ecosystemTypes.EcosystemTypeUbuntu:
+		if !strings.HasPrefix(name, "linux-") {
+			return name
+		}
 		return strings.NewReplacer("linux-signed", "linux", "linux-meta", "linux").Replace(name)
 	default:
 		return name


### PR DESCRIPTION
```golang
func Benchmark_rename(b *testing.B) {
	b.ReportAllocs()
	pkgs := []string{
		"accountsservice",
		"acl",
		"adduser",
		"alsa-lib",
		"alsa-topology-conf",
		"alsa-ucm-conf",
		"apparmor",
		"apport",
		"apport-symptoms",
		"appstream",
		"apt",
		"argon2",
		"at",
		"attr",
		"audit",
		"automat",
		"base-files",
		"base-passwd",
		"bash",
		"bash-completion",
		"bc",
		"bcache-tools",
		"bind9",
		"bind9-libs",
		"blinker",
		"bolt",
		"brotli",
		"bsdmainutils",
		"btrfs-progs",
		"busybox",
		"byobu",
		"bzip2",
		"ca-certificates",
		"cdebconf",
		"chardet",
		"cloud-init",
		"cloud-initramfs-tools",
		"cloud-utils",
		"command-not-found",
		"configobj",
		"console-setup",
		"constantly",
		"coreutils",
		"cpio",
		"cron",
		"cryptsetup",
		"curl",
		"cyrus-sasl2",
		"dash",
		"db5.3",
		"dbus",
		"dbus-python",
		"dconf",
		"dctrl-tools",
		"debconf",
		"debian-goodies",
		"debianutils",
		"diffutils",
		"distro-info",
		"distro-info-data",
		"dmidecode",
		"dosfstools",
		"dpkg",
		"e2fsprogs",
		"ed",
		"efivar",
		"eject",
		"elfutils",
		"entrypoints",
		"ethtool",
		"expat",
		"file",
		"finalrd",
		"findutils",
		"flex",
		"fonts-ubuntu",
		"freetype",
		"fribidi",
		"friendly-recovery",
		"fuse",
		"fwupd",
		"fwupd-signed",
		"gawk",
		"gcab",
		"gcc-10",
		"gdbm",
		"gdisk",
		"gettext",
		"git",
		"glib-networking",
		"glib2.0",
		"glibc",
		"gmp",
		"gnupg2",
		"gnutls28",
		"gobject-introspection",
		"gpgme1.0",
		"gpm",
		"grep",
		"groff",
		"grub-gfxpayload-lists",
		"grub2",
		"gsettings-desktop-schemas",
		"gstreamer1.0",
		"gzip",
		"hdparm",
		"heimdal",
		"hostname",
		"htop",
		"hyperlink",
		"icu",
		"incremental",
		"init-system-helpers",
		"initramfs-tools",
		"iproute2",
		"iptables",
		"iputils",
		"irqbalance",
		"isc-dhcp",
		"iso-codes",
		"jinja2",
		"json-c",
		"json-glib",
		"kbd",
		"keyutils",
		"klibc",
		"kmod",
		"krb5",
		"landscape-client",
		"language-selector",
		"lazr.restfulclient",
		"lazr.uri",
		"less",
		"libaio",
		"libarchive",
		"libassuan",
		"libatasmart",
		"libblockdev",
		"libbsd",
		"libcanberra",
		"libcap-ng",
		"libcap2",
		"libcbor",
		"libdrm",
		"libeatmydata",
		"libedit",
		"liberror-perl",
		"libestr",
		"libevent",
		"libfastjson",
		"libffi",
		"libfido2",
		"libfile-which-perl",
		"libgcrypt20",
		"libgpg-error",
		"libgudev",
		"libgusb",
		"libidn2",
		"libipc-system-simple-perl",
		"libjcat",
		"libksba",
		"liblocale-gettext-perl",
		"libmaxminddb",
		"libmbim",
		"libmnl",
		"libmspack",
		"libnetfilter-conntrack",
		"libnfnetlink",
		"libnftnl",
		"libogg",
		"libpcap",
		"libpipeline",
		"libpng1.6",
		"libproxy",
		"libpsl",
		"libqmi",
		"libseccomp",
		"libselinux",
		"libsemanage",
		"libsepol",
		"libsigsegv",
		"libsmbios",
		"libsodium",
		"libsoup2.4",
		"libssh",
		"libtasn1-6",
		"libtext-charwidth-perl",
		"libtext-iconv-perl",
		"libtext-wrapi18n-perl",
		"libtool",
		"libunistring",
		"libunwind",
		"liburcu",
		"libusb-1.0",
		"libutempter",
		"libuv1",
		"libvorbis",
		"libx11",
		"libxau",
		"libxcb",
		"libxcrypt",
		"libxdmcp",
		"libxext",
		"libxml2",
		"libxmlb",
		"libxmu",
		"libxslt",
		"libyaml",
		"libzstd",
		"linux",
		"linux-atm",
		"linux-base",
		"linux-meta",
		"linux-signed",
		"lmdb",
		"logrotate",
		"lsb",
		"lshw",
		"lsof",
		"ltrace",
		"lvm2",
		"lxd-agent-loader",
		"lz4",
		"lzo2",
		"man-db",
		"manpages",
		"markupsafe",
		"mawk",
		"mdadm",
		"mime-support",
		"modemmanager",
		"more-itertools",
		"mpdecimal",
		"mpfr4",
		"mtr",
		"multipath-tools",
		"nano",
		"ncurses",
		"netbase",
		"netcat-openbsd",
		"netifaces",
		"netkit-ftp",
		"netkit-telnet",
		"netplan.io",
		"nettle",
		"networkd-dispatcher",
		"newt",
		"nghttp2",
		"npth",
		"nspr",
		"nss",
		"ntfs-3g",
		"numactl",
		"open-iscsi",
		"open-isns",
		"open-vm-tools",
		"openldap",
		"openssh",
		"openssl",
		"os-prober",
		"p11-kit",
		"packagekit",
		"pam",
		"parted",
		"pastebinit",
		"patch",
		"pci.ids",
		"pciutils",
		"pcre2",
		"pcre3",
		"perl",
		"pexpect",
		"pinentry",
		"plymouth",
		"policykit-1",
		"pollinate",
		"popt",
		"popularity-contest",
		"powermgmt-base",
		"procps",
		"psmisc",
		"ptyprocess",
		"publicsuffix",
		"pyasn1",
		"pygobject",
		"pyhamcrest",
		"pyjwt",
		"pymacaroons",
		"pyopenssl",
		"pyrsistent",
		"pyserial",
		"python-apt",
		"python-attrs",
		"python-certifi",
		"python-cffi",
		"python-click",
		"python-colorama",
		"python-cryptography",
		"python-debian",
		"python-distro",
		"python-httplib2",
		"python-idna",
		"python-importlib-metadata",
		"python-json-patch",
		"python-json-pointer",
		"python-jsonschema",
		"python-keyring",
		"python-launchpadlib",
		"python-nacl",
		"python-oauthlib",
		"python-pyasn1-modules",
		"python-requests-unixsocket",
		"python-secretstorage",
		"python-service-identity",
		"python-systemd",
		"python-urllib3",
		"python-wadllib",
		"python-zipp",
		"python3-defaults",
		"python3-stdlib-extensions",
		"python3.8",
		"pyyaml",
		"readline",
		"readline5",
		"requests",
		"rsync",
		"rsyslog",
		"rtmpdump",
		"run-one",
		"sbsigntool",
		"screen",
		"secureboot-db",
		"sed",
		"sensible-utils",
		"setuptools",
		"sg3-utils",
		"shadow",
		"shared-mime-info",
		"simplejson",
		"six",
		"slang2",
		"snapd",
		"snowball",
		"software-properties",
		"sosreport",
		"sound-theme-freedesktop",
		"sqlite3",
		"squashfs-tools",
		"ssh-import-id",
		"strace",
		"sudo",
		"systemd",
		"sysvinit",
		"tar",
		"tcp-wrappers",
		"tcpdump",
		"tdb",
		"texinfo",
		"thin-provisioning-tools",
		"time",
		"tmux",
		"tpm-udev",
		"tpm2-tss",
		"twisted",
		"tzdata",
		"ubuntu-advantage-tools",
		"ubuntu-keyring",
		"ubuntu-meta",
		"ubuntu-release-upgrader",
		"ucf",
		"uchardet",
		"udisks2",
		"ufw",
		"unattended-upgrades",
		"update-manager",
		"update-notifier",
		"usb-modeswitch",
		"usb-modeswitch-data",
		"usb.ids",
		"usbutils",
		"util-linux",
		"vim",
		"virtualbox",
		"volume-key",
		"wget",
		"xauth",
		"xdg-user-dirs",
		"xfsprogs",
		"xkeyboard-config",
		"xmlsec1",
		"xz-utils",
		"zerofree",
		"zlib",
		"zope.interface",
	}

	for b.Loop() {
		for _, pkg := range pkgs {
			ospkg.Rename(ecosystemTypes.EcosystemTypeUbuntu, pkg)
		}
	}
}
```

## before
```
$ go test -test.fullpath=true -benchmem -run=^$ -bench ^Benchmark_rename$ -count 6 github.com/MaineK00n/vuls2/pkg/detect/ospkg
goos: linux
goarch: amd64
pkg: github.com/MaineK00n/vuls2/pkg/detect/ospkg
cpu: 12th Gen Intel(R) Core(TM) i7-1280P
Benchmark_rename-20    	    2372	    610059 ns/op	  485026 B/op	    5516 allocs/op
Benchmark_rename-20    	    1790	    738502 ns/op	  485016 B/op	    5516 allocs/op
Benchmark_rename-20    	    1647	    726157 ns/op	  485010 B/op	    5516 allocs/op
Benchmark_rename-20    	    1713	    725205 ns/op	  485013 B/op	    5516 allocs/op
Benchmark_rename-20    	    1833	    686710 ns/op	  485010 B/op	    5516 allocs/op
Benchmark_rename-20    	    1696	    713187 ns/op	  485010 B/op	    5516 allocs/op
PASS
ok  	github.com/MaineK00n/vuls2/pkg/detect/ospkg	7.686s
```

## after
```
$ go test -test.fullpath=true -benchmem -run=^$ -bench ^Benchmark_rename$ -count 6 github.com/MaineK00n/vuls2/pkg/detect/ospkg
goos: linux
goarch: amd64
pkg: github.com/MaineK00n/vuls2/pkg/detect/ospkg
cpu: 12th Gen Intel(R) Core(TM) i7-1280P
Benchmark_rename-20    	  105084	     10634 ns/op	    4928 B/op	      56 allocs/op
Benchmark_rename-20    	  126950	      9610 ns/op	    4928 B/op	      56 allocs/op
Benchmark_rename-20    	  120969	      9542 ns/op	    4928 B/op	      56 allocs/op
Benchmark_rename-20    	  126775	      9541 ns/op	    4928 B/op	      56 allocs/op
Benchmark_rename-20    	  130782	      9569 ns/op	    4928 B/op	      56 allocs/op
Benchmark_rename-20    	  134629	      9450 ns/op	    4928 B/op	      56 allocs/op
PASS
ok  	github.com/MaineK00n/vuls2/pkg/detect/ospkg	7.240s
```