### PR TITLE
fix(scan/cpe): fix CPE copy for scan results

### DIFF
--- a/pkg/scan/types.go
+++ b/pkg/scan/types.go
@@ -7,11 +7,11 @@ type scanResult struct {
 
 	RunningKernel kernel                `json:"runningKernel"`
 	Packages      map[string]binPackage `json:"packages"`
-	SrcPackages   map[string]srcPackage `json:",omitempty"`
+	SrcPackages   map[string]srcPackage `json:"SrcPackages,omitempty"`
 
 	Config struct {
 		Scan config `json:"scan"`
-	}
+	} `json:"config"`
 }
 
 type kernel struct {


### PR DESCRIPTION
Before this PR, CPEs are not copied by case sensitiveness mismatch.
After, it works.

Also, json tag of `SrcPackages` is added to indicate it is intentional.

---------

Setup:

```
[0]% cat 0-res/2025-09-29T19-38-53+0900/cpe-tomcat.json | jq '.config.scan.servers' L
{
  "cpe-tomcat": {
    "serverName": "cpe-tomcat",
    "cpeNames": [
      "cpe:/a:apache:tomcat:10.1.6"
    ],
    "type": "pseudo",
    "wordpress": {},
    "portscan": {},
    "windows": {}
  }
}
```

Before:

```
[0]% rm -rf 2-res/* ; go run ./cmd/vuls scan ./0-res/ --results-dir 2-res
[0]% cat 2-res/7c571727-4bc0-44bf-9f3a-d4fd2a28ebe4/2025-09-29T19-38-53+0900/scan.json | jq .
{
  "json_version": 0,
  "server_uuid": "7c571727-4bc0-44bf-9f3a-d4fd2a28ebe4",
  "server_name": "cpe-tomcat",
  "family": "pseudo",
  "scanned_at": "2026-03-17T18:42:46.458275984+09:00",
  "scanned_by": "vuls (devel)"
}
```

After:

```
[0]% rm -rf 2-res/* ; go run ./cmd/vuls scan ./0-res/ --results-dir 2-res
[0]% cat 2-res/8a11368e-39d5-4b57-a7d6-1558a7659769/2025-09-29T19-38-53+0900/scan.json | jq .
{
  "json_version": 0,
  "server_uuid": "8a11368e-39d5-4b57-a7d6-1558a7659769",
  "server_name": "cpe-tomcat",
  "family": "pseudo",
  "cpe": [
    "cpe:/a:apache:tomcat:10.1.6"
  ],
  "scanned_at": "2026-03-17T18:43:40.904569079+09:00",
  "scanned_by": "vuls (devel)"
}
```