### PR TITLE
feat(cmd/diff-guard): add diff guard to detect buggy db

### DIFF
--- a/pkg/cmd/diff/db/db.go
+++ b/pkg/cmd/diff/db/db.go
@@ -1,0 +1,35 @@
+package db
+
+import (
+	"github.com/spf13/cobra"
+
+	diffdb "github.com/MaineK00n/vuls2/pkg/db/diff/db"
+)
+
+func NewCmd() *cobra.Command {
+	options := struct {
+		changeRateThreshold float64
+		debug               bool
+	}{
+		changeRateThreshold: 0,
+		debug:               false,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "db <baseline-db> <target-db>",
+		Short: "compare detection data directly between two vuls DBs",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return diffdb.DiffBoltDB(
+				args[0], args[1],
+				diffdb.WithChangeRateThreshold(options.changeRateThreshold),
+				diffdb.WithDebug(options.debug),
+			)
+		},
+	}
+
+	cmd.Flags().Float64Var(&options.changeRateThreshold, "change-rate-threshold", options.changeRateThreshold, "change rate (%) threshold per ecosystem; exit non-zero if exceeded")
+	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
+
+	return cmd
+}

--- a/pkg/cmd/diff/detection/detection.go
+++ b/pkg/cmd/diff/detection/detection.go
@@ -1,0 +1,48 @@
+package detection
+
+import (
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	diffdetection "github.com/MaineK00n/vuls2/pkg/db/diff/detection"
+)
+
+func NewCmd() *cobra.Command {
+	options := struct {
+		changeRateThreshold float64
+		debug               bool
+	}{
+		changeRateThreshold: 0,
+		debug:               false,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "detection <scan-results-dir> <baseline-db> <baseline-vuls0-binary> <target-db> <target-vuls0-binary>",
+		Short: "compare detection results between baseline and target (binary, DB) pairs",
+		Args:  cobra.ExactArgs(5),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			for i := range args {
+				abs, err := filepath.Abs(args[i])
+				if err != nil {
+					return errors.Wrapf(err, "abs path. arg: %q", args[i])
+				}
+				args[i] = abs
+			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, args []string) error {
+			return diffdetection.Diff(
+				args[0], args[1], args[2], args[3], args[4],
+				diffdetection.WithChangeRateThreshold(options.changeRateThreshold),
+				diffdetection.WithDebug(options.debug),
+			)
+		},
+	}
+
+	cmd.Flags().Float64Var(&options.changeRateThreshold, "change-rate-threshold", options.changeRateThreshold, "change rate (%) threshold per scan result file; exit non-zero if exceeded")
+	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
+
+	return cmd
+}

--- a/pkg/cmd/diff/diff.go
+++ b/pkg/cmd/diff/diff.go
@@ -1,0 +1,22 @@
+package diff
+
+import (
+	"github.com/spf13/cobra"
+
+	dbCmd "github.com/MaineK00n/vuls2/pkg/cmd/diff/db"
+	detectionCmd "github.com/MaineK00n/vuls2/pkg/cmd/diff/detection"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "compare vuls detection results or DB contents between two versions",
+	}
+
+	cmd.AddCommand(
+		dbCmd.NewCmd(),
+		detectionCmd.NewCmd(),
+	)
+
+	return cmd
+}

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -5,6 +5,7 @@ import (
 
 	dbCmd "github.com/MaineK00n/vuls2/pkg/cmd/db"
 	detectCmd "github.com/MaineK00n/vuls2/pkg/cmd/detect"
+	diffCmd "github.com/MaineK00n/vuls2/pkg/cmd/diff"
 	scanCmd "github.com/MaineK00n/vuls2/pkg/cmd/scan"
 	versionCmd "github.com/MaineK00n/vuls2/pkg/cmd/version"
 )
@@ -22,6 +23,7 @@ func NewCmdRoot() *cobra.Command {
 		dbCmd.NewCmd(),
 		scanCmd.NewCmd(),
 		detectCmd.NewCmd(),
+		diffCmd.NewCmd(),
 		// reportCmd.NewCmd(),
 		versionCmd.NewCmd(),
 	)

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -1,0 +1,625 @@
+package db
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json/v2"
+	"io"
+	"log/slog"
+	"os"
+	"runtime"
+	"slices"
+
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+	"golang.org/x/sync/errgroup"
+
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	microsoftkbTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/microsoftkb"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+)
+
+type options struct {
+	changeRateThreshold float64
+	writer              io.Writer
+	debug               bool
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type changeRateThresholdOption float64
+
+func (o changeRateThresholdOption) apply(opts *options) {
+	opts.changeRateThreshold = float64(o)
+}
+
+func WithChangeRateThreshold(r float64) Option {
+	return changeRateThresholdOption(r)
+}
+
+type writerOption struct{ w io.Writer }
+
+func (o writerOption) apply(opts *options) {
+	opts.writer = o.w
+}
+
+func WithWriter(w io.Writer) Option {
+	return writerOption{w: w}
+}
+
+type debugOption bool
+
+func (o debugOption) apply(opts *options) {
+	opts.debug = bool(o)
+}
+
+func WithDebug(d bool) Option {
+	return debugOption(d)
+}
+
+// EcosystemDiff holds the comparison result for a single ecosystem.
+//
+// An ecosystem bucket may contain a `detection` sub-bucket, a `kb` sub-bucket,
+// or both. Each sub-bucket is diffed independently and has its own change
+// rate so that disparities in magnitude (e.g. many detection units vs few KB
+// units) do not hide a large relative change in the smaller bucket.
+// An ecosystem Passes only when both change rates are within the threshold.
+type EcosystemDiff struct {
+	Ecosystem ecosystemTypes.Ecosystem
+
+	// Detection bucket diff (`<ecosystem>/detection/<Root ID>`).
+	BaselineKeys       int
+	TargetKeys         int
+	Added              []string // root IDs in target but not baseline
+	Removed            []string // root IDs in baseline but not target
+	Changed            []string // root IDs in both but different detection data
+	BaselineCriterions int      // total leaf criterion count across all baseline root IDs
+	TargetCriterions   int      // total leaf criterion count across all target root IDs
+	MatchedCriterions  int      // criterions structurally identical in both (Sort + Compare == 0)
+
+	// KB bucket diff (`<ecosystem>/kb/<KB ID>`).
+	BaselineKBKeys int
+	TargetKBKeys   int
+	AddedKBs       []string // KB IDs in target but not baseline
+	RemovedKBs     []string // KB IDs in baseline but not target
+	ChangedKBs     []string // KB IDs in both but different KB data
+	BaselineKBs    int      // total (KB ID × source ID) pair count in baseline
+	TargetKBs      int      // total (KB ID × source ID) pair count in target
+	MatchedKBs     int      // KB pairs structurally identical in both (Sort + Compare == 0)
+
+	// Per-bucket change rates. When a bucket is absent in both baseline
+	// and target, its rate is 0.
+	DetectionChangeRate float64
+	KBChangeRate        float64
+	Pass                bool
+}
+
+// DiffBoltDB compares detection data directly between two BoltDB files.
+// This intentionally bypasses the Storage abstraction layer and operates on
+// *bolt.DB directly, because the merge-join algorithm requires sorted cursor
+// iteration across two databases simultaneously — a capability the Storage
+// interface does not (and should not) expose. If the storage engine changes,
+// this function will need a corresponding rewrite.
+func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
+	o := &options{
+		changeRateThreshold: 0,
+		writer:              os.Stdout,
+		debug:               false,
+	}
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+
+	if o.debug {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
+	}
+
+	bdb, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		return errors.Wrapf(err, "open baseline DB %s", baselinePath)
+	}
+	defer bdb.Close()
+
+	tdb, err := bolt.Open(targetPath, 0400, &bolt.Options{ReadOnly: true})
+	if err != nil {
+		return errors.Wrapf(err, "open target DB %s", targetPath)
+	}
+	defer tdb.Close()
+
+	baselineEcos, err := getEcosystems(bdb)
+	if err != nil {
+		return errors.Wrap(err, "get baseline ecosystems")
+	}
+	if len(baselineEcos) == 0 {
+		return errors.New("no ecosystems found in baseline DB")
+	}
+
+	total := len(baselineEcos)
+	workers := max(1, min(runtime.NumCPU(), total))
+	ch := make(chan EcosystemDiff, total)
+	g, _ := errgroup.WithContext(context.TODO())
+	g.SetLimit(workers)
+
+	slog.Info("Starting DB diff", "ecosystems", total, "workers", workers)
+
+	// Compare only ecosystems present in the baseline.
+	// New ecosystems in the target are feature additions, not regressions,
+	// so they are intentionally excluded from change rate calculation.
+	for _, eco := range baselineEcos {
+		g.Go(func() error {
+			slog.Debug("ecosystem diff start", "ecosystem", eco)
+
+			d, err := diffEcosystem(bdb, tdb, eco)
+			if err != nil {
+				return errors.Wrapf(err, "diff ecosystem %s", string(eco))
+			}
+
+			d.DetectionChangeRate = changeRate(d.BaselineCriterions, d.TargetCriterions, d.MatchedCriterions)
+			d.KBChangeRate = changeRate(d.BaselineKBs, d.TargetKBs, d.MatchedKBs)
+			d.Pass = d.DetectionChangeRate <= o.changeRateThreshold && d.KBChangeRate <= o.changeRateThreshold
+
+			slog.Debug("ecosystem diff done",
+				"ecosystem", eco, "pass", d.Pass,
+				"detection_change_rate", d.DetectionChangeRate, "target_criterions", d.TargetCriterions,
+				"kb_change_rate", d.KBChangeRate, "target_kbs", d.TargetKBs)
+			ch <- d
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return errors.Wrap(err, "diff ecosystems")
+	}
+	close(ch)
+
+	results := make([]EcosystemDiff, 0, total)
+	for d := range ch {
+		results = append(results, d)
+	}
+
+	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
+	if err != nil {
+		return errors.Wrap(err, "generate report")
+	}
+
+	if !pass {
+		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
+	}
+	return nil
+}
+
+// changeRate computes a per-bucket change rate as a percentage:
+//
+//	(baseline - matched + target - matched) / baseline * 100
+//
+// When baseline is 0 but target has unmatched units, the rate is 100. When
+// both are 0, the rate is 0.
+func changeRate(baseline, target, matched int) float64 {
+	switch {
+	case baseline > 0:
+		return float64(baseline-matched+target-matched) / float64(baseline) * 100
+	case target-matched > 0:
+		return 100
+	default:
+		return 0
+	}
+}
+
+// getEcosystems returns ecosystems that have detection or KB data.
+func getEcosystems(db *bolt.DB) ([]ecosystemTypes.Ecosystem, error) {
+	var ecos []ecosystemTypes.Ecosystem
+	if err := db.View(func(tx *bolt.Tx) error {
+		return tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
+			switch string(name) {
+			case "metadata", "vulnerability", "datasource":
+			default:
+				ecos = append(ecos, ecosystemTypes.Ecosystem(name))
+			}
+			return nil
+		})
+	}); err != nil {
+		return nil, errors.Wrap(err, "db view")
+	}
+	return ecos, nil
+}
+
+// diffEcosystem compares an ecosystem between two DBs by diffing each of its
+// sub-buckets (detection, kb) independently. Either sub-bucket may be absent.
+func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem) (EcosystemDiff, error) {
+	diff := EcosystemDiff{Ecosystem: ecosystem}
+
+	if err := baselineDB.View(func(btx *bolt.Tx) error {
+		return targetDB.View(func(ttx *bolt.Tx) error {
+			bEco := btx.Bucket([]byte(ecosystem))
+			tEco := ttx.Bucket([]byte(ecosystem))
+
+			var bDet, tDet *bolt.Bucket
+			if bEco != nil {
+				bDet = bEco.Bucket([]byte("detection"))
+			}
+			if tEco != nil {
+				tDet = tEco.Bucket([]byte("detection"))
+			}
+			if err := updateDetectionDiff(bDet, tDet, &diff); err != nil {
+				return errors.Wrap(err, "diff detection bucket")
+			}
+
+			var bKB, tKB *bolt.Bucket
+			if bEco != nil {
+				bKB = bEco.Bucket([]byte("kb"))
+			}
+			if tEco != nil {
+				tKB = tEco.Bucket([]byte("kb"))
+			}
+			if err := updateKBDiff(bKB, tKB, &diff); err != nil {
+				return errors.Wrap(err, "diff kb bucket")
+			}
+
+			return nil
+		})
+	}); err != nil {
+		return EcosystemDiff{}, errors.Wrap(err, "diff ecosystem")
+	}
+	return diff, nil
+}
+
+// updateDetectionDiff merge-joins two `<ecosystem>/detection` buckets on sorted
+// cursors and fills the Detection-related fields of diff. Either bucket may
+// be nil.
+func updateDetectionDiff(bDet, tDet *bolt.Bucket, diff *EcosystemDiff) error {
+	if bDet == nil && tDet == nil {
+		return nil
+	}
+
+	if bDet == nil {
+		return tDet.ForEach(func(k, v []byte) error {
+			diff.TargetKeys++
+			diff.Added = append(diff.Added, string(k))
+			n, err := countCriterions(v)
+			if err != nil {
+				return errors.Wrapf(err, "count criterions for target. root ID: %s", string(k))
+			}
+			diff.TargetCriterions += n
+			return nil
+		})
+	}
+
+	if tDet == nil {
+		return bDet.ForEach(func(k, v []byte) error {
+			diff.BaselineKeys++
+			diff.Removed = append(diff.Removed, string(k))
+			n, err := countCriterions(v)
+			if err != nil {
+				return errors.Wrapf(err, "count criterions for baseline. root ID: %s", string(k))
+			}
+			diff.BaselineCriterions += n
+			return nil
+		})
+	}
+
+	// Merge-join: both BoltDB cursors iterate in sorted key order.
+	bc := bDet.Cursor()
+	tc := tDet.Cursor()
+
+	bk, bv := bc.First()
+	tk, tv := tc.First()
+
+	for bk != nil || tk != nil {
+		switch c := func() int {
+			if bk == nil {
+				return +1
+			}
+			if tk == nil {
+				return -1
+			}
+			return bytes.Compare(bk, tk)
+		}(); c {
+		case -1: // baseline-only → Removed
+			diff.BaselineKeys++
+			diff.Removed = append(diff.Removed, string(bk))
+			n, err := countCriterions(bv)
+			if err != nil {
+				return errors.Wrapf(err, "count criterions for baseline. root ID: %s", string(bk))
+			}
+			diff.BaselineCriterions += n
+			bk, bv = bc.Next()
+		case +1: // target-only → Added
+			diff.TargetKeys++
+			diff.Added = append(diff.Added, string(tk))
+			n, err := countCriterions(tv)
+			if err != nil {
+				return errors.Wrapf(err, "count criterions for target. root ID: %s", string(tk))
+			}
+			diff.TargetCriterions += n
+			tk, tv = tc.Next()
+		case 0: // both present → compare
+			diff.BaselineKeys++
+			diff.TargetKeys++
+			base, target, matched, err := compareCriterions(bv, tv)
+			if err != nil {
+				return errors.Wrapf(err, "compare criterions for root ID: %s", string(bk))
+			}
+			diff.BaselineCriterions += base
+			diff.TargetCriterions += target
+			diff.MatchedCriterions += matched
+			if matched < base || matched < target {
+				diff.Changed = append(diff.Changed, string(bk))
+			}
+			bk, bv = bc.Next()
+			tk, tv = tc.Next()
+		default:
+			return errors.Errorf("unexpected compare result. expected: %v, actual: %d", []int{-1, 0, +1}, c)
+		}
+	}
+
+	return nil
+}
+
+// updateKBDiff merge-joins two `<ecosystem>/kb` buckets on sorted cursors and
+// fills the KB-related fields of diff. Either bucket may be nil.
+func updateKBDiff(bKB, tKB *bolt.Bucket, diff *EcosystemDiff) error {
+	if bKB == nil && tKB == nil {
+		return nil
+	}
+
+	if bKB == nil {
+		return tKB.ForEach(func(k, v []byte) error {
+			diff.TargetKBKeys++
+			diff.AddedKBs = append(diff.AddedKBs, string(k))
+			n, err := countKBs(v)
+			if err != nil {
+				return errors.Wrapf(err, "count KBs for target. KB ID: %s", string(k))
+			}
+			diff.TargetKBs += n
+			return nil
+		})
+	}
+
+	if tKB == nil {
+		return bKB.ForEach(func(k, v []byte) error {
+			diff.BaselineKBKeys++
+			diff.RemovedKBs = append(diff.RemovedKBs, string(k))
+			n, err := countKBs(v)
+			if err != nil {
+				return errors.Wrapf(err, "count KBs for baseline. KB ID: %s", string(k))
+			}
+			diff.BaselineKBs += n
+			return nil
+		})
+	}
+
+	bc := bKB.Cursor()
+	tc := tKB.Cursor()
+
+	bk, bv := bc.First()
+	tk, tv := tc.First()
+
+	for bk != nil || tk != nil {
+		switch c := func() int {
+			if bk == nil {
+				return +1
+			}
+			if tk == nil {
+				return -1
+			}
+			return bytes.Compare(bk, tk)
+		}(); c {
+		case -1:
+			diff.BaselineKBKeys++
+			diff.RemovedKBs = append(diff.RemovedKBs, string(bk))
+			n, err := countKBs(bv)
+			if err != nil {
+				return errors.Wrapf(err, "count KBs for baseline. KB ID: %s", string(bk))
+			}
+			diff.BaselineKBs += n
+			bk, bv = bc.Next()
+		case +1:
+			diff.TargetKBKeys++
+			diff.AddedKBs = append(diff.AddedKBs, string(tk))
+			n, err := countKBs(tv)
+			if err != nil {
+				return errors.Wrapf(err, "count KBs for target. KB ID: %s", string(tk))
+			}
+			diff.TargetKBs += n
+			tk, tv = tc.Next()
+		case 0:
+			diff.BaselineKBKeys++
+			diff.TargetKBKeys++
+			base, target, matched, err := compareKBs(bv, tv)
+			if err != nil {
+				return errors.Wrapf(err, "compare KBs for KB ID: %s", string(bk))
+			}
+			diff.BaselineKBs += base
+			diff.TargetKBs += target
+			diff.MatchedKBs += matched
+			if matched < base || matched < target {
+				diff.ChangedKBs = append(diff.ChangedKBs, string(bk))
+			}
+			bk, bv = bc.Next()
+			tk, tv = tc.Next()
+		default:
+			return errors.Errorf("unexpected compare result. expected: %v, actual: %d", []int{-1, 0, +1}, c)
+		}
+	}
+
+	return nil
+}
+
+// compareCriterions structurally compares detection data at the Criterion (leaf) level.
+// It flattens the criteria tree in each condition to extract all criterions,
+// then uses Sort + Compare merge-join to count how many baseline criterions
+// have an identical match in the target.
+//
+// The comparison is structural, not semantic: each leaf criterion is annotated
+// with the operator path from the root Criteria down to its parent, so
+// structurally different but semantically equivalent trees
+// (e.g., AND(A, B, C) vs AND(A, AND(B, C))) are treated as distinct.
+// This is intentional — the vuls-data-update extractor produces a deterministic
+// tree structure for a given data source version, so structural changes always
+// indicate an upstream data change worth surfacing.
+//
+// Returns (baselineCount, targetCount, matchedCount).
+func compareCriterions(baselineData, targetData []byte) (baseline, target, matched int, _ error) {
+	var bm, tm map[sourceTypes.SourceID][]conditionTypes.Condition
+	if err := json.Unmarshal(baselineData, &bm); err != nil {
+		return 0, 0, 0, errors.Wrap(err, "unmarshal baseline criterions")
+	}
+	if err := json.Unmarshal(targetData, &tm); err != nil {
+		return 0, 0, 0, errors.Wrap(err, "unmarshal target criterions")
+	}
+
+	// Iterate over union of source IDs so new/removed sources contribute to change rate.
+	srcs := make(map[sourceTypes.SourceID]struct{}, len(bm))
+	for src := range bm {
+		srcs[src] = struct{}{}
+	}
+	for src := range tm {
+		srcs[src] = struct{}{}
+	}
+
+	flattenAndSort := func(conds []conditionTypes.Condition) []annotatedCriterion {
+		var cns []annotatedCriterion
+		for _, c := range conds {
+			cns = walkCriteria(c.Criteria, nil, cns)
+		}
+		for i := range cns {
+			cns[i].criterion.Sort()
+		}
+		slices.SortFunc(cns, compareAnnotated)
+		return cns
+	}
+
+	for src := range srcs {
+		bCns := flattenAndSort(bm[src])
+		tCns := flattenAndSort(tm[src])
+
+		baseline += len(bCns)
+		target += len(tCns)
+
+		// Merge-join on sorted annotated criterions
+		bi, ti := 0, 0
+		for bi < len(bCns) && ti < len(tCns) {
+			switch c := compareAnnotated(bCns[bi], tCns[ti]); c {
+			case -1:
+				bi++
+			case +1:
+				ti++
+			case 0:
+				matched++
+				bi++
+				ti++
+			default:
+				return 0, 0, 0, errors.Errorf("unexpected compare result. expected: %v, actual: %d", []int{-1, 0, +1}, c)
+			}
+		}
+	}
+	return baseline, target, matched, nil
+}
+
+// annotatedCriterion pairs a leaf Criterion with the operator path from the
+// root Criteria down to its immediate parent.  Two criterions that differ only
+// in their operator context are considered distinct.
+type annotatedCriterion struct {
+	criterion criterionTypes.Criterion
+	operators []criteriaTypes.CriteriaOperatorType
+}
+
+// compareAnnotated compares two annotatedCriterions: first by criterion, then
+// by the operator path.
+func compareAnnotated(a, b annotatedCriterion) int {
+	return cmp.Or(
+		criterionTypes.Compare(a.criterion, b.criterion),
+		slices.Compare(a.operators, b.operators),
+	)
+}
+
+// walkCriteria recursively collects leaf Criterions from the criteria tree,
+// annotating each with the operator path from the root to the current node.
+func walkCriteria(c criteriaTypes.Criteria, opPath []criteriaTypes.CriteriaOperatorType, out []annotatedCriterion) []annotatedCriterion {
+	cur := append(slices.Clone(opPath), c.Operator)
+	for _, cr := range c.Criterions {
+		out = append(out, annotatedCriterion{criterion: cr, operators: cur})
+	}
+	for _, sub := range c.Criterias {
+		out = walkCriteria(sub, cur, out)
+	}
+	return out
+}
+
+// countCriterions unmarshals detection data and returns the total leaf criterion count.
+func countCriterions(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	var m map[sourceTypes.SourceID][]conditionTypes.Condition
+	if err := json.Unmarshal(data, &m); err != nil {
+		return 0, errors.Wrap(err, "unmarshal detection data")
+	}
+	n := 0
+	for _, conds := range m {
+		for _, c := range conds {
+			n += countLeafCriterions(c.Criteria)
+		}
+	}
+	return n, nil
+}
+
+// countLeafCriterions recursively counts leaf Criterions in the criteria tree.
+func countLeafCriterions(c criteriaTypes.Criteria) int {
+	n := len(c.Criterions)
+	for _, sub := range c.Criterias {
+		n += countLeafCriterions(sub)
+	}
+	return n
+}
+
+// compareKBs structurally compares KB data at the (KB ID × source ID) pair level.
+// The input bytes are the marshaled value of `<ecosystem>/kb/<KB ID>`, i.e. a
+// map[sourceTypes.SourceID]microsoftkbTypes.KB. Returns per-source counts:
+// (baselineCount, targetCount, matchedCount).
+func compareKBs(baselineData, targetData []byte) (baseline, target, matched int, _ error) {
+	var bm, tm map[sourceTypes.SourceID]microsoftkbTypes.KB
+	if err := json.Unmarshal(baselineData, &bm); err != nil {
+		return 0, 0, 0, errors.Wrap(err, "unmarshal baseline KBs")
+	}
+	if err := json.Unmarshal(targetData, &tm); err != nil {
+		return 0, 0, 0, errors.Wrap(err, "unmarshal target KBs")
+	}
+
+	baseline = len(bm)
+	target = len(tm)
+
+	for src, bKB := range bm {
+		tKB, ok := tm[src]
+		if !ok {
+			continue
+		}
+		bKB.Sort()
+		tKB.Sort()
+		if microsoftkbTypes.Compare(bKB, tKB) == 0 {
+			matched++
+		}
+	}
+	return baseline, target, matched, nil
+}
+
+// countKBs unmarshals KB data and returns the number of (KB ID × source ID)
+// pairs it contributes (i.e. len of the source map).
+func countKBs(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	var m map[sourceTypes.SourceID]microsoftkbTypes.KB
+	if err := json.Unmarshal(data, &m); err != nil {
+		return 0, errors.Wrap(err, "unmarshal KB data")
+	}
+	return len(m), nil
+}

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -122,24 +122,41 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 		})))
 	}
 
-	bdb, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
+	baselibeDB, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return errors.Wrapf(err, "open baseline DB %s", baselinePath)
 	}
-	defer bdb.Close()
+	defer baselibeDB.Close()
 
-	tdb, err := bolt.Open(targetPath, 0400, &bolt.Options{ReadOnly: true})
+	targetDB, err := bolt.Open(targetPath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return errors.Wrapf(err, "open target DB %s", targetPath)
 	}
-	defer tdb.Close()
+	defer targetDB.Close()
 
-	baselineEcos, err := getEcosystems(bdb)
+	results, err := computeDiffs(baselibeDB, targetDB, o.changeRateThreshold)
 	if err != nil {
-		return errors.Wrap(err, "get baseline ecosystems")
+		return errors.Wrap(err, "compute diffs")
+	}
+
+	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
+	if err != nil {
+		return errors.Wrap(err, "generate report")
+	}
+
+	if !pass {
+		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
+	}
+	return nil
+}
+
+func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64) ([]EcosystemDiff, error) {
+	baselineEcos, err := getEcosystems(baselineDB)
+	if err != nil {
+		return nil, errors.Wrap(err, "get baseline ecosystems")
 	}
 	if len(baselineEcos) == 0 {
-		return errors.New("no ecosystems found in baseline DB")
+		return nil, errors.New("no ecosystems found in baseline DB")
 	}
 
 	total := len(baselineEcos)
@@ -157,14 +174,10 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 		g.Go(func() error {
 			slog.Debug("ecosystem diff start", "ecosystem", eco)
 
-			d, err := diffEcosystem(bdb, tdb, eco)
+			d, err := diffEcosystem(baselineDB, targetDB, eco, changeRateThreshold)
 			if err != nil {
 				return errors.Wrapf(err, "diff ecosystem %s", string(eco))
 			}
-
-			d.DetectionChangeRate = changeRate(d.BaselineCriterions, d.TargetCriterions, d.MatchedCriterions)
-			d.KBChangeRate = changeRate(d.BaselineKBs, d.TargetKBs, d.MatchedKBs)
-			d.Pass = d.DetectionChangeRate <= o.changeRateThreshold && d.KBChangeRate <= o.changeRateThreshold
 
 			slog.Debug("ecosystem diff done",
 				"ecosystem", eco, "pass", d.Pass,
@@ -176,7 +189,7 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 
 	if err := g.Wait(); err != nil {
-		return errors.Wrap(err, "diff ecosystems")
+		return nil, errors.Wrap(err, "diff ecosystems")
 	}
 	close(ch)
 
@@ -184,16 +197,7 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	for d := range ch {
 		results = append(results, d)
 	}
-
-	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
-	if err != nil {
-		return errors.Wrap(err, "generate report")
-	}
-
-	if !pass {
-		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
-	}
-	return nil
+	return results, nil
 }
 
 // changeRate computes a per-bucket change rate as a percentage:
@@ -233,7 +237,7 @@ func getEcosystems(db *bolt.DB) ([]ecosystemTypes.Ecosystem, error) {
 
 // diffEcosystem compares an ecosystem between two DBs by diffing each of its
 // sub-buckets (detection, kb) independently. Either sub-bucket may be absent.
-func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem) (EcosystemDiff, error) {
+func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem, changeRateThreshold float64) (EcosystemDiff, error) {
 	diff := EcosystemDiff{Ecosystem: ecosystem}
 
 	if err := baselineDB.View(func(btx *bolt.Tx) error {
@@ -268,6 +272,10 @@ func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosy
 	}); err != nil {
 		return EcosystemDiff{}, errors.Wrap(err, "diff ecosystem")
 	}
+
+	diff.DetectionChangeRate = changeRate(diff.BaselineCriterions, diff.TargetCriterions, diff.MatchedCriterions)
+	diff.KBChangeRate = changeRate(diff.BaselineKBs, diff.TargetKBs, diff.MatchedKBs)
+	diff.Pass = diff.DetectionChangeRate <= changeRateThreshold && diff.KBChangeRate <= changeRateThreshold
 	return diff, nil
 }
 

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -122,11 +122,11 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 		})))
 	}
 
-	baselibeDB, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
+	baselineDB, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
 		return errors.Wrapf(err, "open baseline DB %s", baselinePath)
 	}
-	defer baselibeDB.Close()
+	defer baselineDB.Close()
 
 	targetDB, err := bolt.Open(targetPath, 0400, &bolt.Options{ReadOnly: true})
 	if err != nil {
@@ -134,7 +134,7 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 	defer targetDB.Close()
 
-	results, err := computeDiffs(baselibeDB, targetDB, o.changeRateThreshold)
+	results, err := computeDiffs(baselineDB, targetDB, o.changeRateThreshold)
 	if err != nil {
 		return errors.Wrap(err, "compute diffs")
 	}

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -1,0 +1,1223 @@
+package db_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+
+	db "github.com/MaineK00n/vuls2/pkg/db/diff/db"
+	"github.com/MaineK00n/vuls2/pkg/db/session"
+)
+
+// populateDB creates a BoltDB at dbPath populated from fixture directories.
+func populateDB(dbPath string, fixtureDirs ...string) error {
+	c := session.Config{
+		Type:    "boltdb",
+		Path:    dbPath,
+		Options: session.StorageOptions{BoltDB: bolt.DefaultOptions},
+	}
+	s, err := c.New()
+	if err != nil {
+		return errors.Wrap(err, "session.New")
+	}
+	if err := s.Storage().Open(); err != nil {
+		return errors.Wrap(err, "storage.Open")
+	}
+	defer s.Storage().Close()
+	if err := s.Storage().Initialize(); err != nil {
+		return errors.Wrap(err, "storage.Initialize")
+	}
+	for _, fixtureDir := range fixtureDirs {
+		entries, err := os.ReadDir(fixtureDir)
+		if err != nil {
+			return errors.Wrapf(err, "ReadDir(%s)", fixtureDir)
+		}
+		for _, e := range entries {
+			if err := s.Storage().Put(filepath.Join(fixtureDir, e.Name())); err != nil {
+				return errors.Wrapf(err, "storage.Put(%s)", e.Name())
+			}
+		}
+	}
+	return nil
+}
+
+func TestGetEcosystems(t *testing.T) {
+	type args struct {
+		fixture string
+	}
+	tests := []struct {
+		name string
+		args args
+		want []ecosystemTypes.Ecosystem
+	}{
+		{
+			name: "alma errata",
+			args: args{
+				fixture: "testdata/fixtures/baseline",
+			},
+			want: []ecosystemTypes.Ecosystem{"alma:8"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dbPath := filepath.Join(t.TempDir(), "vuls.db")
+			if err := populateDB(dbPath, tt.args.fixture); err != nil {
+				t.Fatal(err)
+			}
+
+			bdb, err := bolt.Open(dbPath, 0400, &bolt.Options{ReadOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer bdb.Close()
+
+			got, err := db.GetEcosystems(bdb)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("GetEcosystems() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiffEcosystem(t *testing.T) {
+	type args struct {
+		baselineFixture string
+		targetFixture   string
+		ecosystem       ecosystemTypes.Ecosystem
+	}
+	tests := []struct {
+		name string
+		args args
+		want db.EcosystemDiff
+	}{
+		{
+			name: "no change",
+			args: args{
+				baselineFixture: "testdata/fixtures/baseline",
+				targetFixture:   "testdata/fixtures/target-same",
+				ecosystem:       "alma:8",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "alma:8",
+				BaselineKeys:       1,
+				TargetKeys:         1,
+				BaselineCriterions: 6,
+				TargetCriterions:   6,
+				MatchedCriterions:  6,
+			},
+		},
+		{
+			name: "added and removed",
+			args: args{
+				baselineFixture: "testdata/fixtures/baseline",
+				targetFixture:   "testdata/fixtures/target-replaced",
+				ecosystem:       "alma:8",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "alma:8",
+				BaselineKeys:       1,
+				TargetKeys:         1,
+				Added:              []string{"ALSA-2019:3708"},
+				Removed:            []string{"ALSA-2024:0113"},
+				BaselineCriterions: 6,
+				TargetCriterions:   6,
+			},
+		},
+		{
+			name: "changed",
+			args: args{
+				baselineFixture: "testdata/fixtures/baseline",
+				targetFixture:   "testdata/fixtures/target-changed",
+				ecosystem:       "alma:8",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "alma:8",
+				BaselineKeys:       1,
+				TargetKeys:         1,
+				Changed:            []string{"ALSA-2024:0113"},
+				BaselineCriterions: 6,
+				TargetCriterions:   6,
+				MatchedCriterions:  5,
+			},
+		},
+		{
+			name: "target missing ecosystem",
+			args: args{
+				baselineFixture: "testdata/fixtures/baseline",
+				targetFixture:   "", // empty; set to t.TempDir() in run loop
+				ecosystem:       "alma:8",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "alma:8",
+				BaselineKeys:       1,
+				Removed:            []string{"ALSA-2024:0113"},
+				BaselineCriterions: 6,
+			},
+		},
+		{
+			name: "target added key",
+			args: args{
+				baselineFixture: "testdata/fixtures/baseline",
+				targetFixture:   "testdata/fixtures/target-added",
+				ecosystem:       "alma:8",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "alma:8",
+				BaselineKeys:       1,
+				TargetKeys:         2,
+				Added:              []string{"ALSA-2019:3708"},
+				BaselineCriterions: 6,
+				TargetCriterions:   12,
+				MatchedCriterions:  6,
+			},
+		},
+		{
+			name: "criterion change",
+			args: args{
+				baselineFixture: "testdata/fixtures/change-baseline",
+				targetFixture:   "testdata/fixtures/change-target",
+				ecosystem:       "test:change",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:          "test:change",
+				BaselineKeys:       2,
+				TargetKeys:         2,
+				Changed:            []string{"ROOT-0001", "ROOT-0002"},
+				BaselineCriterions: 6,
+				TargetCriterions:   2,
+				MatchedCriterions:  0,
+			},
+		},
+		{
+			name: "kb no change",
+			args: args{
+				baselineFixture: "testdata/fixtures/kb-baseline",
+				targetFixture:   "testdata/fixtures/kb-target-same",
+				ecosystem:       "microsoft",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:      "microsoft",
+				BaselineKBKeys: 2,
+				TargetKBKeys:   2,
+				BaselineKBs:    2,
+				TargetKBs:      2,
+				MatchedKBs:     2,
+			},
+		},
+		{
+			name: "kb added",
+			args: args{
+				baselineFixture: "testdata/fixtures/kb-baseline",
+				targetFixture:   "testdata/fixtures/kb-target-added",
+				ecosystem:       "microsoft",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:      "microsoft",
+				BaselineKBKeys: 2,
+				TargetKBKeys:   3,
+				AddedKBs:       []string{"KB5001222"},
+				BaselineKBs:    2,
+				TargetKBs:      3,
+				MatchedKBs:     2,
+			},
+		},
+		{
+			name: "kb changed",
+			args: args{
+				baselineFixture: "testdata/fixtures/kb-baseline",
+				targetFixture:   "testdata/fixtures/kb-target-changed",
+				ecosystem:       "microsoft",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:      "microsoft",
+				BaselineKBKeys: 2,
+				TargetKBKeys:   2,
+				ChangedKBs:     []string{"KB5001111"},
+				BaselineKBs:    2,
+				TargetKBs:      2,
+				MatchedKBs:     1,
+			},
+		},
+		{
+			name: "target missing kb ecosystem",
+			args: args{
+				baselineFixture: "testdata/fixtures/kb-baseline",
+				targetFixture:   "", // empty; set to t.TempDir() in run loop
+				ecosystem:       "microsoft",
+			},
+			want: db.EcosystemDiff{
+				Ecosystem:      "microsoft",
+				BaselineKBKeys: 2,
+				RemovedKBs:     []string{"KB5001000", "KB5001111"},
+				BaselineKBs:    2,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baselineFixture := tt.args.baselineFixture
+			if baselineFixture == "" {
+				baselineFixture = t.TempDir()
+			}
+			baselinePath := filepath.Join(t.TempDir(), "vuls.db")
+			if err := populateDB(baselinePath, baselineFixture); err != nil {
+				t.Fatal(err)
+			}
+			targetFixture := tt.args.targetFixture
+			if targetFixture == "" {
+				targetFixture = t.TempDir()
+			}
+			targetPath := filepath.Join(t.TempDir(), "vuls.db")
+			if err := populateDB(targetPath, targetFixture); err != nil {
+				t.Fatal(err)
+			}
+
+			bdb, err := bolt.Open(baselinePath, 0400, &bolt.Options{ReadOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer bdb.Close()
+
+			tdb, err := bolt.Open(targetPath, 0400, &bolt.Options{ReadOnly: true})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tdb.Close()
+
+			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("DiffEcosystem() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiffBoltDB(t *testing.T) {
+	type args struct {
+		baselineFixtures    []string
+		targetFixtures      []string
+		changeRateThreshold float64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "fail on removed root",
+			args: args{
+				baselineFixtures:    []string{"testdata/fixtures/target-added"},
+				targetFixtures:      []string{"testdata/fixtures/baseline"},
+				changeRateThreshold: 10,
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass identical",
+			args: args{
+				baselineFixtures:    []string{"testdata/fixtures/baseline"},
+				targetFixtures:      []string{"testdata/fixtures/target-same"},
+				changeRateThreshold: 10,
+			},
+			wantErr: false,
+		},
+		{
+			// Target-only ecosystems are excluded from change rate calculation (baseline-only policy).
+			name: "pass target-only ecosystem ignored",
+			args: args{
+				baselineFixtures:    []string{"testdata/fixtures/baseline"},                                      // alma:8
+				targetFixtures:      []string{"testdata/fixtures/baseline", "testdata/fixtures/change-baseline"}, // alma:8 + test:change
+				changeRateThreshold: 0,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baselinePath := filepath.Join(t.TempDir(), "vuls.db")
+			if err := populateDB(baselinePath, tt.args.baselineFixtures...); err != nil {
+				t.Fatal(err)
+			}
+			targetPath := filepath.Join(t.TempDir(), "vuls.db")
+			if err := populateDB(targetPath, tt.args.targetFixtures...); err != nil {
+				t.Fatal(err)
+			}
+
+			gotErr := db.DiffBoltDB(
+				baselinePath, targetPath,
+				db.WithChangeRateThreshold(tt.args.changeRateThreshold),
+				db.WithWriter(&bytes.Buffer{}),
+			)
+
+			if (gotErr != nil) != tt.wantErr {
+				t.Fatalf("DiffBoltDB() error = %v, wantErr %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCompareCriterions(t *testing.T) {
+	type args struct {
+		baseline string
+		target   string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantBaseline int
+		wantTarget   int
+		wantMatched  int
+		wantErr      bool
+	}{
+		{
+			name: "identical",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "criteria removed",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"operator": "AND", "criterions": [{"type": "version"}]}},
+						{"criteria": {"operator": "OR",  "criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"operator": "AND", "criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 2,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "criteria added in target",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"operator": "AND", "criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"operator": "AND", "criterions": [{"type": "version"}]}},
+						{"criteria": {"operator": "OR",  "criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   2,
+			wantMatched:  1,
+		},
+		{
+			name: "operator changed only (criterions identical)",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"operator": "AND", "criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"operator": "OR", "criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+		{
+			name: "criterion type changed",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "none-exist"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+		{
+			name: "source removed",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					],
+					"src2": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 2,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "target invalid data",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+				target: `not json`,
+			},
+			wantBaseline: 0,
+			wantTarget:   0,
+			wantMatched:  0,
+			wantErr:      true,
+		},
+		{
+			name: "baseline invalid data",
+			args: args{
+				baseline: `not json`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 0,
+			wantTarget:   0,
+			wantMatched:  0,
+			wantErr:      true,
+		},
+		{
+			name: "empty baseline",
+			args: args{
+				baseline: `{}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "version"}]}}
+					]
+				}`,
+			},
+			wantBaseline: 0,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+		{
+			name: "kb criterion identical",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "kb", "kb": {"product": "Windows 11", "kb_id": "KB5001234"}}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "kb", "kb": {"product": "Windows 11", "kb_id": "KB5001234"}}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "kb criterion changed",
+			args: args{
+				baseline: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "kb", "kb": {"product": "Windows 11", "kb_id": "KB5001234"}}]}}
+					]
+				}`,
+				target: `{
+					"src1": [
+						{"criteria": {"criterions": [{"type": "kb", "kb": {"product": "Windows 11", "kb_id": "KB5005678"}}]}}
+					]
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline, target, matched, err := db.CompareCriterions([]byte(tt.args.baseline), []byte(tt.args.target))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CompareCriterions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if baseline != tt.wantBaseline {
+				t.Errorf("baseline = %d, want %d", baseline, tt.wantBaseline)
+			}
+			if target != tt.wantTarget {
+				t.Errorf("target = %d, want %d", target, tt.wantTarget)
+			}
+			if matched != tt.wantMatched {
+				t.Errorf("matched = %d, want %d", matched, tt.wantMatched)
+			}
+		})
+	}
+}
+
+func TestCountCriterions(t *testing.T) {
+	type args struct {
+		data string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{data: `{}`},
+			want: 0,
+		},
+		{
+			name: "no conditions",
+			args: args{data: `{"src1":[]}`},
+			want: 0,
+		},
+		{
+			name: "one criterion",
+			args: args{data: `{
+				"src1": [
+					{"criteria": {"criterions": [{"type": "version"}]}}
+				]
+			}`},
+			want: 1,
+		},
+		{
+			name: "nested criteria counts all leaf criterions",
+			args: args{data: `{
+				"src1": [
+					{"criteria": {"operator": "OR", "criterias": [
+						{"criterions": [{"type": "version"}, {"type": "version"}]},
+						{"criterions": [{"type": "version"}]}
+					]}}
+				]
+			}`},
+			want: 3,
+		},
+		{
+			name: "multiple sources",
+			args: args{data: `{
+				"src1": [
+					{"criteria": {"criterions": [{"type": "version"}]}}
+				],
+				"src2": [
+					{"criteria": {"criterions": [{"type": "version"}, {"type": "version"}]}}
+				]
+			}`},
+			want: 3,
+		},
+		{
+			name: "multiple conditions per source",
+			args: args{data: `{
+				"src1": [
+					{"criteria": {"criterions": [{"type": "version"}]}},
+					{"criteria": {"criterions": [{"type": "version"}]}}
+				]
+			}`},
+			want: 2,
+		},
+		{
+			name: "kb criterion",
+			args: args{data: `{
+				"src1": [
+					{"criteria": {"criterions": [{"type": "kb", "kb": {"product": "Windows 11", "kb_id": "KB5001234"}}]}}
+				]
+			}`},
+			want: 1,
+		},
+		{
+			name:    "invalid json",
+			args:    args{data: `not json`},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.CountCriterions([]byte(tt.args.data))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CountCriterions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CountCriterions() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompareKBs(t *testing.T) {
+	type args struct {
+		baseline string
+		target   string
+	}
+	tests := []struct {
+		name         string
+		args         args
+		wantBaseline int
+		wantTarget   int
+		wantMatched  int
+		wantErr      bool
+	}{
+		{
+			name: "identical single source",
+			args: args{
+				baseline: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"url": "https://example.com",
+						"products": ["Windows 11"]
+					}
+				}`,
+				target: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"url": "https://example.com",
+						"products": ["Windows 11"]
+					}
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "products differ",
+			args: args{
+				baseline: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"products": ["Windows 11"]
+					}
+				}`,
+				target: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"products": ["Windows 11", "Windows Server"]
+					}
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+		{
+			name: "products reordered still match after Sort",
+			args: args{
+				baseline: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"products": ["Windows Server", "Windows 11"]
+					}
+				}`,
+				target: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"products": ["Windows 11", "Windows Server"]
+					}
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "superseded_by differs only",
+			args: args{
+				baseline: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"superseded_by": [
+							{"kb_id": "KB5002000"}
+						]
+					}
+				}`,
+				target: `{
+					"src1": {
+						"kb_id": "KB5001234",
+						"superseded_by": [
+							{"kb_id": "KB5002000"},
+							{"kb_id": "KB5003000"}
+						]
+					}
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   1,
+			wantMatched:  0,
+		},
+		{
+			name: "source added in target",
+			args: args{
+				baseline: `{
+					"src1": {"kb_id": "KB5001234"}
+				}`,
+				target: `{
+					"src1": {"kb_id": "KB5001234"},
+					"src2": {"kb_id": "KB5001234"}
+				}`,
+			},
+			wantBaseline: 1,
+			wantTarget:   2,
+			wantMatched:  1,
+		},
+		{
+			name: "source removed in target",
+			args: args{
+				baseline: `{
+					"src1": {"kb_id": "KB5001234"},
+					"src2": {"kb_id": "KB5001234"}
+				}`,
+				target: `{
+					"src1": {"kb_id": "KB5001234"}
+				}`,
+			},
+			wantBaseline: 2,
+			wantTarget:   1,
+			wantMatched:  1,
+		},
+		{
+			name: "baseline invalid data",
+			args: args{
+				baseline: `not json`,
+				target: `{
+					"src1": {"kb_id": "KB5001234"}
+				}`,
+			},
+			wantErr: true,
+		},
+		{
+			name: "target invalid data",
+			args: args{
+				baseline: `{
+					"src1": {"kb_id": "KB5001234"}
+				}`,
+				target: `not json`,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseline, target, matched, err := db.CompareKBs([]byte(tt.args.baseline), []byte(tt.args.target))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CompareKBs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if baseline != tt.wantBaseline {
+				t.Errorf("baseline = %d, want %d", baseline, tt.wantBaseline)
+			}
+			if target != tt.wantTarget {
+				t.Errorf("target = %d, want %d", target, tt.wantTarget)
+			}
+			if matched != tt.wantMatched {
+				t.Errorf("matched = %d, want %d", matched, tt.wantMatched)
+			}
+		})
+	}
+}
+
+func TestCountKBs(t *testing.T) {
+	type args struct {
+		data string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    int
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{data: `{}`},
+			want: 0,
+		},
+		{
+			name: "one source",
+			args: args{data: `{
+				"src1": {"kb_id": "KB5001234"}
+			}`},
+			want: 1,
+		},
+		{
+			name: "multiple sources",
+			args: args{data: `{
+				"src1": {"kb_id": "KB5001234"},
+				"src2": {"kb_id": "KB5001234"}
+			}`},
+			want: 2,
+		},
+		{
+			name:    "invalid json",
+			args:    args{data: `not json`},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := db.CountKBs([]byte(tt.args.data))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CountKBs() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("CountKBs() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateReport(t *testing.T) {
+	type args struct {
+		diffs               []db.EcosystemDiff
+		changeRateThreshold float64
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantPass   bool
+		wantReport string
+	}{
+		{
+			name: "fail with details",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:           "redhat:9",
+						BaselineKeys:        100,
+						TargetKeys:          100,
+						BaselineCriterions:  500,
+						TargetCriterions:    500,
+						MatchedCriterions:   500,
+						DetectionChangeRate: 0,
+						Pass:                true,
+					},
+					{
+						Ecosystem:           "ubuntu:22.04",
+						BaselineKeys:        800,
+						TargetKeys:          200,
+						BaselineCriterions:  4000,
+						TargetCriterions:    2000,
+						MatchedCriterions:   1000,
+						Removed:             []string{"CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0003"},
+						Changed:             []string{"CVE-2024-0004"},
+						DetectionChangeRate: 75.0,
+						Pass:                false,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: DB
+
+**Result**: FAIL
+**Change Rate Threshold**:     10.0%
+**Detection Change Rate Max**: 75.0% (ubuntu:22.04)
+**KB Change Rate Max**:        0.0%
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+| ubuntu:22.04 | 75.0% | 0.0% | **FAIL** |
+| redhat:9 | 0.0% | 0.0% | PASS |
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| ubuntu:22.04 | 800 | 200 | 0 | 3 | 1 | 4000 | 2000 | 1000 |
+| redhat:9 | 100 | 100 | 0 | 0 | 0 | 500 | 500 | 500 |
+
+## Details (FAIL ecosystems)
+
+### ubuntu:22.04
+
+#### Removed Root IDs (3)
+
+- CVE-2024-0001
+- CVE-2024-0002
+- CVE-2024-0003
+
+#### Changed Root IDs (1)
+
+- CVE-2024-0004
+
+`,
+		},
+		{
+			name: "pass all ecosystems",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:           "alma:8",
+						BaselineKeys:        50,
+						TargetKeys:          52,
+						Added:               []string{"ALSA-2025-0001", "ALSA-2025-0002"},
+						BaselineCriterions:  200,
+						TargetCriterions:    210,
+						MatchedCriterions:   200,
+						DetectionChangeRate: 4.8,
+						Pass:                true,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: true,
+			wantReport: `# Diff Report: DB
+
+**Result**: PASS
+**Change Rate Threshold**:     10.0%
+**Detection Change Rate Max**: 4.8% (alma:8)
+**KB Change Rate Max**:        0.0%
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+| alma:8 | 4.8% | 0.0% | PASS |
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| alma:8 | 50 | 52 | 2 | 0 | 0 | 200 | 210 | 200 |
+
+`,
+		},
+		{
+			name: "fail with kb changes",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:      "microsoft",
+						BaselineKBKeys: 10,
+						TargetKBKeys:   10,
+						BaselineKBs:    10,
+						TargetKBs:      10,
+						MatchedKBs:     3,
+						ChangedKBs:     []string{"KB5001", "KB5002"},
+						AddedKBs:       []string{"KB5003"},
+						RemovedKBs:     []string{"KB4000"},
+						KBChangeRate:   140.0,
+						Pass:           false,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: DB
+
+**Result**: FAIL
+**Change Rate Threshold**:     10.0%
+**Detection Change Rate Max**: 0.0%
+**KB Change Rate Max**:        140.0% (microsoft)
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+| microsoft | 0.0% | 140.0% | **FAIL** |
+
+## KB
+
+| Ecosystem | Baseline KB Keys | Target KB Keys | Added | Removed | Changed | Baseline KBs | Target KBs | Matched KBs |
+|-----------|------------------|----------------|-------|---------|---------|--------------|------------|-------------|
+| microsoft | 10 | 10 | 1 | 1 | 2 | 10 | 10 | 3 |
+
+## Details (FAIL ecosystems)
+
+### microsoft
+
+#### Added KB IDs (1)
+
+- KB5003
+
+#### Removed KB IDs (1)
+
+- KB4000
+
+#### Changed KB IDs (2)
+
+- KB5001
+- KB5002
+
+`,
+		},
+		{
+			name: "pass with detection and kb",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:          "alma:8",
+						BaselineKeys:       10,
+						TargetKeys:         10,
+						BaselineCriterions: 50,
+						TargetCriterions:   50,
+						MatchedCriterions:  50,
+						Pass:               true,
+					},
+					{
+						Ecosystem:      "microsoft",
+						BaselineKBKeys: 5,
+						TargetKBKeys:   5,
+						BaselineKBs:    5,
+						TargetKBs:      5,
+						MatchedKBs:     5,
+						Pass:           true,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: true,
+			wantReport: `# Diff Report: DB
+
+**Result**: PASS
+**Change Rate Threshold**:     10.0%
+**Detection Change Rate Max**: 0.0%
+**KB Change Rate Max**:        0.0%
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+| alma:8 | 0.0% | 0.0% | PASS |
+| microsoft | 0.0% | 0.0% | PASS |
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| alma:8 | 10 | 10 | 0 | 0 | 0 | 50 | 50 | 50 |
+
+## KB
+
+| Ecosystem | Baseline KB Keys | Target KB Keys | Added | Removed | Changed | Baseline KBs | Target KBs | Matched KBs |
+|-----------|------------------|----------------|-------|---------|---------|--------------|------------|-------------|
+| microsoft | 5 | 5 | 0 | 0 | 0 | 5 | 5 | 5 |
+
+`,
+		},
+		{
+			// Demonstrates why detection and KB rates must be reported
+			// separately: detection change (1.5%) is well within threshold,
+			// but KB change (80%) in a much smaller bucket indicates a real
+			// regression that a combined rate would dilute.
+			name: "fail only on kb despite passing detection",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:           "mixed:1",
+						BaselineKeys:        100,
+						TargetKeys:          100,
+						BaselineCriterions:  10000,
+						TargetCriterions:    10050,
+						MatchedCriterions:   9950,
+						BaselineKBKeys:      5,
+						TargetKBKeys:        5,
+						BaselineKBs:         5,
+						TargetKBs:           5,
+						MatchedKBs:          3,
+						ChangedKBs:          []string{"KB1", "KB2"},
+						DetectionChangeRate: 1.5,
+						KBChangeRate:        80.0,
+						Pass:                false,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: DB
+
+**Result**: FAIL
+**Change Rate Threshold**:     10.0%
+**Detection Change Rate Max**: 1.5% (mixed:1)
+**KB Change Rate Max**:        80.0% (mixed:1)
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+| mixed:1 | 1.5% | 80.0% | **FAIL** |
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| mixed:1 | 100 | 100 | 0 | 0 | 0 | 10000 | 10050 | 9950 |
+
+## KB
+
+| Ecosystem | Baseline KB Keys | Target KB Keys | Added | Removed | Changed | Baseline KBs | Target KBs | Matched KBs |
+|-----------|------------------|----------------|-------|---------|---------|--------------|------------|-------------|
+| mixed:1 | 5 | 5 | 0 | 0 | 2 | 5 | 5 | 3 |
+
+## Details (FAIL ecosystems)
+
+### mixed:1
+
+#### Changed KB IDs (2)
+
+- KB1
+- KB2
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			gotPass, err := db.GenerateReport(&buf, tt.args.diffs, tt.args.changeRateThreshold)
+			if err != nil {
+				t.Fatalf("GenerateReport() error = %v", err)
+			}
+			if gotPass != tt.wantPass {
+				t.Errorf("GenerateReport() pass = %v, want %v", gotPass, tt.wantPass)
+			}
+			got := buf.String()
+			if diff := cmp.Diff(tt.wantReport, got); diff != "" {
+				t.Errorf("GenerateReport() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -960,11 +960,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: **FAIL**
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       75.0% (ubuntu:22.04)
-
 ## Summary
+
+**Result**: **FAIL** (Change Rate Threshold: 10.0%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
@@ -980,7 +978,7 @@ func TestGenerateReport(t *testing.T) {
 
 ## Details (FAIL ecosystems)
 
-### ubuntu:22.04
+### ubuntu:22.04 (75.0%)
 
 #### Removed Root IDs (3)
 
@@ -1015,11 +1013,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: true,
 			wantReport: `# Diff Report: DB
 
-**Result**: PASS
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       4.8% (alma:8)
-
 ## Summary
+
+**Result**: PASS (Change Rate Threshold: 10.0%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
@@ -1056,11 +1052,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: **FAIL**
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       140.0% (microsoft)
-
 ## Summary
+
+**Result**: **FAIL** (Change Rate Threshold: 10.0%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
@@ -1074,7 +1068,7 @@ func TestGenerateReport(t *testing.T) {
 
 ## Details (FAIL ecosystems)
 
-### microsoft
+### microsoft (0.0%)
 
 #### Added KB IDs (1)
 
@@ -1119,11 +1113,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: true,
 			wantReport: `# Diff Report: DB
 
-**Result**: PASS
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       0.0%
-
 ## Summary
+
+**Result**: PASS (Change Rate Threshold: 10.0%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
@@ -1175,11 +1167,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: **FAIL**
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       80.0% (mixed:1)
-
 ## Summary
+
+**Result**: **FAIL** (Change Rate Threshold: 10.0%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
@@ -1199,7 +1189,7 @@ func TestGenerateReport(t *testing.T) {
 
 ## Details (FAIL ecosystems)
 
-### mixed:1
+### mixed:1 (1.5%)
 
 #### Changed KB IDs (2)
 

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -115,6 +115,7 @@ func TestDiffEcosystem(t *testing.T) {
 				BaselineCriterions: 6,
 				TargetCriterions:   6,
 				MatchedCriterions:  6,
+				Pass:               true,
 			},
 		},
 		{
@@ -125,13 +126,14 @@ func TestDiffEcosystem(t *testing.T) {
 				ecosystem:       "alma:8",
 			},
 			want: db.EcosystemDiff{
-				Ecosystem:          "alma:8",
-				BaselineKeys:       1,
-				TargetKeys:         1,
-				Added:              []string{"ALSA-2019:3708"},
-				Removed:            []string{"ALSA-2024:0113"},
-				BaselineCriterions: 6,
-				TargetCriterions:   6,
+				Ecosystem:           "alma:8",
+				BaselineKeys:        1,
+				TargetKeys:          1,
+				Added:               []string{"ALSA-2019:3708"},
+				Removed:             []string{"ALSA-2024:0113"},
+				BaselineCriterions:  6,
+				TargetCriterions:    6,
+				DetectionChangeRate: 200,
 			},
 		},
 		{
@@ -142,13 +144,14 @@ func TestDiffEcosystem(t *testing.T) {
 				ecosystem:       "alma:8",
 			},
 			want: db.EcosystemDiff{
-				Ecosystem:          "alma:8",
-				BaselineKeys:       1,
-				TargetKeys:         1,
-				Changed:            []string{"ALSA-2024:0113"},
-				BaselineCriterions: 6,
-				TargetCriterions:   6,
-				MatchedCriterions:  5,
+				Ecosystem:           "alma:8",
+				BaselineKeys:        1,
+				TargetKeys:          1,
+				Changed:             []string{"ALSA-2024:0113"},
+				BaselineCriterions:  6,
+				TargetCriterions:    6,
+				MatchedCriterions:   5,
+				DetectionChangeRate: float64(6-5+6-5) / float64(6) * 100,
 			},
 		},
 		{
@@ -159,10 +162,11 @@ func TestDiffEcosystem(t *testing.T) {
 				ecosystem:       "alma:8",
 			},
 			want: db.EcosystemDiff{
-				Ecosystem:          "alma:8",
-				BaselineKeys:       1,
-				Removed:            []string{"ALSA-2024:0113"},
-				BaselineCriterions: 6,
+				Ecosystem:           "alma:8",
+				BaselineKeys:        1,
+				Removed:             []string{"ALSA-2024:0113"},
+				BaselineCriterions:  6,
+				DetectionChangeRate: 100,
 			},
 		},
 		{
@@ -173,13 +177,14 @@ func TestDiffEcosystem(t *testing.T) {
 				ecosystem:       "alma:8",
 			},
 			want: db.EcosystemDiff{
-				Ecosystem:          "alma:8",
-				BaselineKeys:       1,
-				TargetKeys:         2,
-				Added:              []string{"ALSA-2019:3708"},
-				BaselineCriterions: 6,
-				TargetCriterions:   12,
-				MatchedCriterions:  6,
+				Ecosystem:           "alma:8",
+				BaselineKeys:        1,
+				TargetKeys:          2,
+				Added:               []string{"ALSA-2019:3708"},
+				BaselineCriterions:  6,
+				TargetCriterions:    12,
+				MatchedCriterions:   6,
+				DetectionChangeRate: 100,
 			},
 		},
 		{
@@ -190,13 +195,14 @@ func TestDiffEcosystem(t *testing.T) {
 				ecosystem:       "test:change",
 			},
 			want: db.EcosystemDiff{
-				Ecosystem:          "test:change",
-				BaselineKeys:       2,
-				TargetKeys:         2,
-				Changed:            []string{"ROOT-0001", "ROOT-0002"},
-				BaselineCriterions: 6,
-				TargetCriterions:   2,
-				MatchedCriterions:  0,
+				Ecosystem:           "test:change",
+				BaselineKeys:        2,
+				TargetKeys:          2,
+				Changed:             []string{"ROOT-0001", "ROOT-0002"},
+				BaselineCriterions:  6,
+				TargetCriterions:    2,
+				MatchedCriterions:   0,
+				DetectionChangeRate: float64(6-0+2-0) / float64(6) * 100,
 			},
 		},
 		{
@@ -213,6 +219,7 @@ func TestDiffEcosystem(t *testing.T) {
 				BaselineKBs:    2,
 				TargetKBs:      2,
 				MatchedKBs:     2,
+				Pass:           true,
 			},
 		},
 		{
@@ -230,6 +237,7 @@ func TestDiffEcosystem(t *testing.T) {
 				BaselineKBs:    2,
 				TargetKBs:      3,
 				MatchedKBs:     2,
+				KBChangeRate:   50,
 			},
 		},
 		{
@@ -247,6 +255,7 @@ func TestDiffEcosystem(t *testing.T) {
 				BaselineKBs:    2,
 				TargetKBs:      2,
 				MatchedKBs:     1,
+				KBChangeRate:   100,
 			},
 		},
 		{
@@ -261,6 +270,7 @@ func TestDiffEcosystem(t *testing.T) {
 				BaselineKBKeys: 2,
 				RemovedKBs:     []string{"KB5001000", "KB5001111"},
 				BaselineKBs:    2,
+				KBChangeRate:   100,
 			},
 		},
 	}
@@ -295,7 +305,7 @@ func TestDiffEcosystem(t *testing.T) {
 			}
 			defer tdb.Close()
 
-			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem)
+			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem, 0)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -950,7 +960,7 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: FAIL
+**Result**: **FAIL**
 **Change Rate Threshold**:     10.0%
 **Detection Change Rate Max**: 75.0% (ubuntu:22.04)
 **KB Change Rate Max**:        0.0%
@@ -1048,7 +1058,7 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: FAIL
+**Result**: **FAIL**
 **Change Rate Threshold**:     10.0%
 **Detection Change Rate Max**: 0.0%
 **KB Change Rate Max**:        140.0% (microsoft)
@@ -1169,7 +1179,7 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
-**Result**: FAIL
+**Result**: **FAIL**
 **Change Rate Threshold**:     10.0%
 **Detection Change Rate Max**: 1.5% (mixed:1)
 **KB Change Rate Max**:        80.0% (mixed:1)

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -961,9 +961,8 @@ func TestGenerateReport(t *testing.T) {
 			wantReport: `# Diff Report: DB
 
 **Result**: **FAIL**
-**Change Rate Threshold**:     10.0%
-**Detection Change Rate Max**: 75.0% (ubuntu:22.04)
-**KB Change Rate Max**:        0.0%
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       75.0% (ubuntu:22.04)
 
 ## Summary
 
@@ -1017,9 +1016,8 @@ func TestGenerateReport(t *testing.T) {
 			wantReport: `# Diff Report: DB
 
 **Result**: PASS
-**Change Rate Threshold**:     10.0%
-**Detection Change Rate Max**: 4.8% (alma:8)
-**KB Change Rate Max**:        0.0%
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       4.8% (alma:8)
 
 ## Summary
 
@@ -1059,9 +1057,8 @@ func TestGenerateReport(t *testing.T) {
 			wantReport: `# Diff Report: DB
 
 **Result**: **FAIL**
-**Change Rate Threshold**:     10.0%
-**Detection Change Rate Max**: 0.0%
-**KB Change Rate Max**:        140.0% (microsoft)
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       140.0% (microsoft)
 
 ## Summary
 
@@ -1123,9 +1120,8 @@ func TestGenerateReport(t *testing.T) {
 			wantReport: `# Diff Report: DB
 
 **Result**: PASS
-**Change Rate Threshold**:     10.0%
-**Detection Change Rate Max**: 0.0%
-**KB Change Rate Max**:        0.0%
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       0.0%
 
 ## Summary
 
@@ -1180,9 +1176,8 @@ func TestGenerateReport(t *testing.T) {
 			wantReport: `# Diff Report: DB
 
 **Result**: **FAIL**
-**Change Rate Threshold**:     10.0%
-**Detection Change Rate Max**: 1.5% (mixed:1)
-**KB Change Rate Max**:        80.0% (mixed:1)
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       80.0% (mixed:1)
 
 ## Summary
 

--- a/pkg/db/diff/db/export_test.go
+++ b/pkg/db/diff/db/export_test.go
@@ -1,0 +1,11 @@
+package db
+
+var (
+	GetEcosystems     = getEcosystems
+	DiffEcosystem     = diffEcosystem
+	CompareCriterions = compareCriterions
+	CountCriterions   = countCriterions
+	CompareKBs        = compareKBs
+	CountKBs          = countKBs
+	GenerateReport    = generateReport
+)

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -1,0 +1,202 @@
+package db
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+
+	"github.com/pkg/errors"
+)
+
+// maxRate returns the larger of the two per-bucket rates for sorting/reporting.
+func maxRate(d EcosystemDiff) float64 {
+	return max(d.DetectionChangeRate, d.KBChangeRate)
+}
+
+// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
+// the name part when the rate is 0 (no non-zero change exists).
+func formatMax(rate float64, name string) string {
+	if name == "" {
+		return fmt.Sprintf("%.1f%%", rate)
+	}
+	return fmt.Sprintf("%.1f%% (%s)", rate, name)
+}
+
+// generateReport writes a Markdown report for DB diff to w.
+// It returns whether all ecosystems passed and any write error.
+func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
+	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
+		return cmp.Or(
+			cmp.Compare(maxRate(b), maxRate(a)),
+			cmp.Compare(a.Ecosystem, b.Ecosystem),
+		)
+	})
+
+	pass := !slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return !r.Pass })
+
+	overallResult := func() string {
+		if !pass {
+			return "FAIL"
+		}
+		return "PASS"
+	}()
+
+	detMaxName, detMax := "", 0.0
+	kbMaxName, kbMax := "", 0.0
+	for _, d := range diffs {
+		if d.DetectionChangeRate > detMax {
+			detMax = d.DetectionChangeRate
+			detMaxName = string(d.Ecosystem)
+		}
+		if d.KBChangeRate > kbMax {
+			kbMax = d.KBChangeRate
+			kbMaxName = string(d.Ecosystem)
+		}
+	}
+
+	if _, err := fmt.Fprintf(w, `# Diff Report: DB
+
+**Result**: %s
+**Change Rate Threshold**:     %.1f%%
+**Detection Change Rate Max**: %s
+**KB Change Rate Max**:        %s
+
+## Summary
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Result |
+|-----------|-----------------------|----------------|--------|
+`, overallResult, changeRateThreshold, formatMax(detMax, detMaxName), formatMax(kbMax, kbMaxName)); err != nil {
+		return false, errors.Wrap(err, "write header")
+	}
+	for _, d := range diffs {
+		result := func() string {
+			if !d.Pass {
+				return "**FAIL**"
+			}
+			return "PASS"
+		}()
+		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %s |\n",
+			d.Ecosystem,
+			d.DetectionChangeRate,
+			d.KBChangeRate,
+			result); err != nil {
+			return false, errors.Wrap(err, "write summary row")
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return false, errors.Wrap(err, "write summary separator")
+	}
+
+	hasAnyDetection := slices.ContainsFunc(diffs, func(d EcosystemDiff) bool {
+		return d.BaselineKeys > 0 || d.TargetKeys > 0
+	})
+	if hasAnyDetection {
+		if _, err := fmt.Fprintf(w, `## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+`); err != nil {
+			return false, errors.Wrap(err, "write detection header")
+		}
+		for _, d := range diffs {
+			if d.BaselineKeys == 0 && d.TargetKeys == 0 {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+				d.Ecosystem, d.BaselineKeys, d.TargetKeys,
+				len(d.Added), len(d.Removed), len(d.Changed),
+				d.BaselineCriterions, d.TargetCriterions, d.MatchedCriterions); err != nil {
+				return false, errors.Wrap(err, "write detection row")
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return false, errors.Wrap(err, "write detection separator")
+		}
+	}
+
+	if slices.ContainsFunc(diffs, func(d EcosystemDiff) bool {
+		return d.BaselineKBKeys > 0 || d.TargetKBKeys > 0
+	}) {
+		if _, err := fmt.Fprintf(w, `## KB
+
+| Ecosystem | Baseline KB Keys | Target KB Keys | Added | Removed | Changed | Baseline KBs | Target KBs | Matched KBs |
+|-----------|------------------|----------------|-------|---------|---------|--------------|------------|-------------|
+`); err != nil {
+			return false, errors.Wrap(err, "write kb header")
+		}
+		for _, d := range diffs {
+			if d.BaselineKBKeys == 0 && d.TargetKBKeys == 0 {
+				continue
+			}
+			if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %d | %d | %d | %d |\n",
+				d.Ecosystem, d.BaselineKBKeys, d.TargetKBKeys,
+				len(d.AddedKBs), len(d.RemovedKBs), len(d.ChangedKBs),
+				d.BaselineKBs, d.TargetKBs, d.MatchedKBs); err != nil {
+				return false, errors.Wrap(err, "write kb row")
+			}
+		}
+		if _, err := fmt.Fprintln(w); err != nil {
+			return false, errors.Wrap(err, "write kb separator")
+		}
+	}
+
+	// Details for FAIL ecosystems
+	var failDiffs []EcosystemDiff
+	for _, d := range diffs {
+		if !d.Pass {
+			failDiffs = append(failDiffs, d)
+		}
+	}
+
+	if len(failDiffs) > 0 {
+		if _, err := fmt.Fprintf(w, "## Details (FAIL ecosystems)\n\n"); err != nil {
+			return false, errors.Wrap(err, "write details header")
+		}
+		for _, d := range failDiffs {
+			if _, err := fmt.Fprintf(w, "### %s\n\n", d.Ecosystem); err != nil {
+				return false, errors.Wrapf(err, "write ecosystem header %s", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Added Root IDs", d.Added); err != nil {
+				return false, errors.Wrapf(err, "%s added", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Removed Root IDs", d.Removed); err != nil {
+				return false, errors.Wrapf(err, "%s removed", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Changed Root IDs", d.Changed); err != nil {
+				return false, errors.Wrapf(err, "%s changed", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Added KB IDs", d.AddedKBs); err != nil {
+				return false, errors.Wrapf(err, "%s added KBs", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Removed KB IDs", d.RemovedKBs); err != nil {
+				return false, errors.Wrapf(err, "%s removed KBs", d.Ecosystem)
+			}
+			if err := writeIDList(w, "Changed KB IDs", d.ChangedKBs); err != nil {
+				return false, errors.Wrapf(err, "%s changed KBs", d.Ecosystem)
+			}
+		}
+	}
+
+	return pass, nil
+}
+
+// writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.
+// It is a no-op when ids is empty.
+func writeIDList(w io.Writer, label string, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "#### %s (%d)\n\n", label, len(ids)); err != nil {
+		return errors.Wrap(err, "write header")
+	}
+	for _, id := range ids {
+		if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
+			return errors.Wrap(err, "write id")
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return errors.Wrap(err, "write separator")
+	}
+	return nil
+}

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -12,6 +12,10 @@ import (
 // generateReport writes a Markdown report for DB diff to w.
 // It returns whether all ecosystems passed and any write error.
 func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
+	if len(diffs) == 0 {
+		return true, errors.New("no ecosystems to compare")
+	}
+
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
 			-cmp.Compare(max(a.DetectionChangeRate, a.KBChangeRate),
@@ -22,19 +26,11 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 
 	pass := !slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return !r.Pass })
 
-	detMaxDiff := slices.MaxFunc(diffs, func(a, b EcosystemDiff) int {
-		return cmp.Compare(a.DetectionChangeRate, b.DetectionChangeRate)
-	})
-	kbMaxDiff := slices.MaxFunc(diffs, func(a, b EcosystemDiff) int {
-		return cmp.Compare(a.KBChangeRate, b.KBChangeRate)
-	})
-
 	if _, err := fmt.Fprintf(w, `# Diff Report: DB
 
 **Result**: %s
-**Change Rate Threshold**:     %.1f%%
-**Detection Change Rate Max**: %s
-**KB Change Rate Max**:        %s
+**Change Rate Threshold**: %.1f%%
+**Change Rate Max**:       %s
 
 ## Summary
 
@@ -43,8 +39,7 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 `,
 		resultLabel(pass),
 		changeRateThreshold,
-		formatMax(detMaxDiff.DetectionChangeRate, string(detMaxDiff.Ecosystem)),
-		formatMax(kbMaxDiff.KBChangeRate, string(kbMaxDiff.Ecosystem)),
+		formatMax(max(diffs[0].DetectionChangeRate, diffs[0].KBChangeRate), string(diffs[0].Ecosystem)),
 	); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -28,18 +28,15 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: DB
 
-**Result**: %s
-**Change Rate Threshold**: %.1f%%
-**Change Rate Max**:       %s
-
 ## Summary
+
+**Result**: %s (Change Rate Threshold: %.1f%%)
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
 `,
 		resultLabel(pass),
 		changeRateThreshold,
-		formatMax(max(diffs[0].DetectionChangeRate, diffs[0].KBChangeRate), string(diffs[0].Ecosystem)),
 	); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
@@ -122,7 +119,7 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 			return false, errors.Wrap(err, "write details header")
 		}
 		for _, d := range failDiffs {
-			if _, err := fmt.Fprintf(w, "### %s\n\n", d.Ecosystem); err != nil {
+			if _, err := fmt.Fprintf(w, "### %s (%.1f%%)\n\n", d.Ecosystem, d.DetectionChangeRate); err != nil {
 				return false, errors.Wrapf(err, "write ecosystem header %s", d.Ecosystem)
 			}
 			if err := writeIDList(w, "Added Root IDs", d.Added); err != nil {
@@ -147,15 +144,6 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 	}
 
 	return pass, nil
-}
-
-// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
-// the name part when the rate is 0 (no non-zero change exists).
-func formatMax(rate float64, name string) string {
-	if rate == 0 {
-		return fmt.Sprintf("%.1f%%", rate)
-	}
-	return fmt.Sprintf("%.1f%% (%s)", rate, name)
 }
 
 func resultLabel(pass bool) string {

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -14,8 +14,8 @@ import (
 func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
-			cmp.Compare(max(b.DetectionChangeRate, b.KBChangeRate),
-				max(a.DetectionChangeRate, a.KBChangeRate)),
+			cmp.Compare(-max(a.DetectionChangeRate, a.KBChangeRate),
+				-max(b.DetectionChangeRate, b.KBChangeRate)),
 			cmp.Compare(a.Ecosystem, b.Ecosystem),
 		)
 	})

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -14,8 +14,8 @@ import (
 func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
-			cmp.Compare(-max(a.DetectionChangeRate, a.KBChangeRate),
-				-max(b.DetectionChangeRate, b.KBChangeRate)),
+			-cmp.Compare(max(a.DetectionChangeRate, a.KBChangeRate),
+				max(b.DetectionChangeRate, b.KBChangeRate)),
 			cmp.Compare(a.Ecosystem, b.Ecosystem),
 		)
 	})

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -9,51 +9,25 @@ import (
 	"github.com/pkg/errors"
 )
 
-// maxRate returns the larger of the two per-bucket rates for sorting/reporting.
-func maxRate(d EcosystemDiff) float64 {
-	return max(d.DetectionChangeRate, d.KBChangeRate)
-}
-
-// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
-// the name part when the rate is 0 (no non-zero change exists).
-func formatMax(rate float64, name string) string {
-	if name == "" {
-		return fmt.Sprintf("%.1f%%", rate)
-	}
-	return fmt.Sprintf("%.1f%% (%s)", rate, name)
-}
-
 // generateReport writes a Markdown report for DB diff to w.
 // It returns whether all ecosystems passed and any write error.
 func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
-			cmp.Compare(maxRate(b), maxRate(a)),
+			cmp.Compare(max(b.DetectionChangeRate, b.KBChangeRate),
+				max(a.DetectionChangeRate, a.KBChangeRate)),
 			cmp.Compare(a.Ecosystem, b.Ecosystem),
 		)
 	})
 
 	pass := !slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return !r.Pass })
 
-	overallResult := func() string {
-		if !pass {
-			return "FAIL"
-		}
-		return "PASS"
-	}()
-
-	detMaxName, detMax := "", 0.0
-	kbMaxName, kbMax := "", 0.0
-	for _, d := range diffs {
-		if d.DetectionChangeRate > detMax {
-			detMax = d.DetectionChangeRate
-			detMaxName = string(d.Ecosystem)
-		}
-		if d.KBChangeRate > kbMax {
-			kbMax = d.KBChangeRate
-			kbMaxName = string(d.Ecosystem)
-		}
-	}
+	detMaxDiff := slices.MaxFunc(diffs, func(a, b EcosystemDiff) int {
+		return cmp.Compare(a.DetectionChangeRate, b.DetectionChangeRate)
+	})
+	kbMaxDiff := slices.MaxFunc(diffs, func(a, b EcosystemDiff) int {
+		return cmp.Compare(a.KBChangeRate, b.KBChangeRate)
+	})
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: DB
 
@@ -66,21 +40,21 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 
 | Ecosystem | Detection Change Rate | KB Change Rate | Result |
 |-----------|-----------------------|----------------|--------|
-`, overallResult, changeRateThreshold, formatMax(detMax, detMaxName), formatMax(kbMax, kbMaxName)); err != nil {
+`,
+		resultLabel(pass),
+		changeRateThreshold,
+		formatMax(detMaxDiff.DetectionChangeRate, string(detMaxDiff.Ecosystem)),
+		formatMax(kbMaxDiff.KBChangeRate, string(kbMaxDiff.Ecosystem)),
+	); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 	for _, d := range diffs {
-		result := func() string {
-			if !d.Pass {
-				return "**FAIL**"
-			}
-			return "PASS"
-		}()
 		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %s |\n",
 			d.Ecosystem,
 			d.DetectionChangeRate,
 			d.KBChangeRate,
-			result); err != nil {
+			resultLabel(d.Pass),
+		); err != nil {
 			return false, errors.Wrap(err, "write summary row")
 		}
 	}
@@ -88,10 +62,9 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 		return false, errors.Wrap(err, "write summary separator")
 	}
 
-	hasAnyDetection := slices.ContainsFunc(diffs, func(d EcosystemDiff) bool {
+	if slices.ContainsFunc(diffs, func(d EcosystemDiff) bool {
 		return d.BaselineKeys > 0 || d.TargetKeys > 0
-	})
-	if hasAnyDetection {
+	}) {
 		if _, err := fmt.Fprintf(w, `## Detection
 
 | Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
@@ -179,6 +152,22 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 	}
 
 	return pass, nil
+}
+
+// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
+// the name part when the rate is 0 (no non-zero change exists).
+func formatMax(rate float64, name string) string {
+	if rate == 0 {
+		return fmt.Sprintf("%.1f%%", rate)
+	}
+	return fmt.Sprintf("%.1f%% (%s)", rate, name)
+}
+
+func resultLabel(pass bool) string {
+	if pass {
+		return "PASS"
+	}
+	return "**FAIL**"
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/db/testdata/fixtures/baseline/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
+++ b/pkg/db/diff/db/testdata/fixtures/baseline/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
@@ -1,0 +1,367 @@
+{
+	"id": "ALSA-2024:0113",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2024:0113",
+				"title": "Important: kernel security update",
+				"description": "The kernel packages contain the Linux kernel, the core of any Linux operating system.\n\nSecurity Fix(es):\n\n* kernel: use after free in unix_stream_sendpage (CVE-2023-4622)\n* kernel: vmwgfx: reference count issue leads to use-after-free in surface handling (CVE-2023-5633)\n* kernel: netfilter: potential slab-out-of-bound access due to integer underflow (CVE-2023-42753)\n* Kernel: UAF during login when accessing the shost ipaddress (CVE-2023-2162)\n* hw amd: Return Address Predictor vulnerability leading to information disclosure (CVE-2023-20569)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Backport OVS l4 Symmetric Hashing to almalinux-8 (JIRA:AlmaLinux-12746)\n* Unbounded memory usage by TCP for receive buffers (JIRA:AlmaLinux-15096)\n* various kind of guests freeze on rhel 8.8 (JIRA:AlmaLinux-15121)\n* AlmaLinux 8: netfilter: conntrack: Fix gre tunneling over ipv6  (JIRA:AlmaLinux-15259)\n* NFSv4.1 needs to handle ENOENT error from GETDEVICEINFO (JIRA:AlmaLinux-16407)\n* DM multipath showing failed path for an nvme-o-FC LUN when performing I/O operations (JIRA:AlmaLinux-14718)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/errata/RHSA-2024:0113"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2187773"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2207625"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2237760"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2239843"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2245663"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2024-0113.html"
+					}
+				],
+				"published": "2024-01-10T00:00:00Z",
+				"modified": "2024-01-17T10:35:17Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-20569",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2162",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-42753",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-4622",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-5633",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-doc",
+											"architectures": [
+												"noarch"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"vuls-data-raw-alma-errata/8/ALSA/2024/ALSA-2024:0113.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/baseline/alma-errata/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/baseline/alma-errata/datasource.json
@@ -1,0 +1,1 @@
+{"id":"alma-errata","name":"AlmaLinux Errata"}

--- a/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/data/ROOT/ROOT-0001.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/data/ROOT/ROOT-0001.json
@@ -1,0 +1,109 @@
+{
+    "id": "ROOT-0001",
+    "advisories": [],
+    "vulnerabilities": [],
+    "detections": [
+        {
+            "ecosystem": "test:change",
+            "conditions": [
+                {
+                    "criteria": {
+                        "operator": "OR",
+                        "criterias": [
+                            {
+                                "criterions": [
+                                    {
+                                        "type": "version",
+                                        "version": {
+                                            "vulnerable": true,
+                                            "fix_status": {
+                                                "class": "fixed"
+                                            },
+                                            "package": {
+                                                "type": "binary",
+                                                "binary": {
+                                                    "name": "pkg-a"
+                                                }
+                                            },
+                                            "affected": {
+                                                "type": "rpm",
+                                                "range": [
+                                                    {
+                                                        "lt": "1.0.0"
+                                                    }
+                                                ],
+                                                "fixed": [
+                                                    "1.0.0"
+                                                ]
+                                            }
+                                        }
+                                    },
+                                    {
+                                        "type": "version",
+                                        "version": {
+                                            "vulnerable": true,
+                                            "fix_status": {
+                                                "class": "fixed"
+                                            },
+                                            "package": {
+                                                "type": "binary",
+                                                "binary": {
+                                                    "name": "pkg-b"
+                                                }
+                                            },
+                                            "affected": {
+                                                "type": "rpm",
+                                                "range": [
+                                                    {
+                                                        "lt": "1.0.0"
+                                                    }
+                                                ],
+                                                "fixed": [
+                                                    "1.0.0"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            },
+                            {
+                                "criterions": [
+                                    {
+                                        "type": "version",
+                                        "version": {
+                                            "vulnerable": true,
+                                            "fix_status": {
+                                                "class": "fixed"
+                                            },
+                                            "package": {
+                                                "type": "binary",
+                                                "binary": {
+                                                    "name": "pkg-c"
+                                                }
+                                            },
+                                            "affected": {
+                                                "type": "rpm",
+                                                "range": [
+                                                    {
+                                                        "lt": "1.0.0"
+                                                    }
+                                                ],
+                                                "fixed": [
+                                                    "1.0.0"
+                                                ]
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "data_source": {
+        "id": "test-source",
+        "raws": []
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/data/ROOT/ROOT-0002.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/data/ROOT/ROOT-0002.json
@@ -1,0 +1,109 @@
+{
+	"id": "ROOT-0002",
+	"advisories": [],
+	"vulnerabilities": [],
+	"detections": [
+		{
+			"ecosystem": "test:change",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "fixed"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "pkg-a"
+												}
+											},
+											"affected": {
+												"type": "rpm",
+												"range": [
+													{
+														"lt": "1.0.0"
+													}
+												],
+												"fixed": [
+													"1.0.0"
+												]
+											}
+										}
+									},
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "fixed"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "pkg-b"
+												}
+											},
+											"affected": {
+												"type": "rpm",
+												"range": [
+													{
+														"lt": "1.0.0"
+													}
+												],
+												"fixed": [
+													"1.0.0"
+												]
+											}
+										}
+									}
+								]
+							},
+							{
+								"criterions": [
+									{
+										"type": "version",
+										"version": {
+											"vulnerable": true,
+											"fix_status": {
+												"class": "fixed"
+											},
+											"package": {
+												"type": "binary",
+												"binary": {
+													"name": "pkg-c"
+												}
+											},
+											"affected": {
+												"type": "rpm",
+												"range": [
+													{
+														"lt": "1.0.0"
+													}
+												],
+												"fixed": [
+													"1.0.0"
+												]
+											}
+										}
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "test-source",
+		"raws": []
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-baseline/test-source/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "test-source",
+	"name": "Test Source"
+}

--- a/pkg/db/diff/db/testdata/fixtures/change-target/test-source/data/ROOT/ROOT-0001.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-target/test-source/data/ROOT/ROOT-0001.json
@@ -1,0 +1,48 @@
+{
+    "id": "ROOT-0001",
+    "advisories": [],
+    "vulnerabilities": [],
+    "detections": [
+        {
+            "ecosystem": "test:change",
+            "conditions": [
+                {
+                    "criteria": {
+                        "criterions": [
+                            {
+                                "type": "version",
+                                "version": {
+                                    "vulnerable": true,
+                                    "fix_status": {
+                                        "class": "fixed"
+                                    },
+                                    "package": {
+                                        "type": "binary",
+                                        "binary": {
+                                            "name": "pkg-a"
+                                        }
+                                    },
+                                    "affected": {
+                                        "type": "rpm",
+                                        "range": [
+                                            {
+                                                "lt": "1.0.0"
+                                            }
+                                        ],
+                                        "fixed": [
+                                            "1.0.0"
+                                        ]
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    ],
+    "data_source": {
+        "id": "test-source",
+        "raws": []
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/change-target/test-source/data/ROOT/ROOT-0002.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-target/test-source/data/ROOT/ROOT-0002.json
@@ -1,0 +1,48 @@
+{
+	"id": "ROOT-0002",
+	"advisories": [],
+	"vulnerabilities": [],
+	"detections": [
+		{
+			"ecosystem": "test:change",
+			"conditions": [
+				{
+					"criteria": {
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "pkg-a"
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "1.0.0"
+											}
+										],
+										"fixed": [
+											"1.0.0"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "test-source",
+		"raws": []
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/change-target/test-source/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/change-target/test-source/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "test-source",
+	"name": "Test Source"
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/datasource.json
@@ -1,0 +1,4 @@
+{
+    "id": "microsoft-cvrf",
+    "name": "Microsoft CVRF"
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/microsoftkb/KB5001000.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/microsoftkb/KB5001000.json
@@ -1,0 +1,10 @@
+{
+    "kb_id": "KB5001000",
+    "url": "https://support.microsoft.com/kb/5001000",
+    "products": [
+        "Windows 11"
+    ],
+    "data_source": {
+        "id": "microsoft-cvrf"
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/microsoftkb/KB5001111.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-baseline/microsoft-cvrf/microsoftkb/KB5001111.json
@@ -1,0 +1,10 @@
+{
+    "kb_id": "KB5001111",
+    "url": "https://support.microsoft.com/kb/5001111",
+    "products": [
+        "Windows 10"
+    ],
+    "data_source": {
+        "id": "microsoft-cvrf"
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/datasource.json
@@ -1,0 +1,1 @@
+{"id":"microsoft-cvrf","name":"Microsoft CVRF"}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001000.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001000.json
@@ -1,0 +1,1 @@
+{"kb_id":"KB5001000","url":"https://support.microsoft.com/kb/5001000","products":["Windows 11"],"data_source":{"id":"microsoft-cvrf"}}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001111.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001111.json
@@ -1,0 +1,1 @@
+{"kb_id":"KB5001111","url":"https://support.microsoft.com/kb/5001111","products":["Windows 10"],"data_source":{"id":"microsoft-cvrf"}}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001222.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-added/microsoft-cvrf/microsoftkb/KB5001222.json
@@ -1,0 +1,10 @@
+{
+    "kb_id": "KB5001222",
+    "url": "https://support.microsoft.com/kb/5001222",
+    "products": [
+        "Windows Server 2022"
+    ],
+    "data_source": {
+        "id": "microsoft-cvrf"
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/datasource.json
@@ -1,0 +1,1 @@
+{"id":"microsoft-cvrf","name":"Microsoft CVRF"}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/microsoftkb/KB5001000.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/microsoftkb/KB5001000.json
@@ -1,0 +1,1 @@
+{"kb_id":"KB5001000","url":"https://support.microsoft.com/kb/5001000","products":["Windows 11"],"data_source":{"id":"microsoft-cvrf"}}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/microsoftkb/KB5001111.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-changed/microsoft-cvrf/microsoftkb/KB5001111.json
@@ -1,0 +1,11 @@
+{
+    "kb_id": "KB5001111",
+    "url": "https://support.microsoft.com/kb/5001111",
+    "products": [
+        "Windows 10",
+        "Windows Server 2019"
+    ],
+    "data_source": {
+        "id": "microsoft-cvrf"
+    }
+}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/datasource.json
@@ -1,0 +1,1 @@
+{"id":"microsoft-cvrf","name":"Microsoft CVRF"}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/microsoftkb/KB5001000.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/microsoftkb/KB5001000.json
@@ -1,0 +1,1 @@
+{"kb_id":"KB5001000","url":"https://support.microsoft.com/kb/5001000","products":["Windows 11"],"data_source":{"id":"microsoft-cvrf"}}

--- a/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/microsoftkb/KB5001111.json
+++ b/pkg/db/diff/db/testdata/fixtures/kb-target-same/microsoft-cvrf/microsoftkb/KB5001111.json
@@ -1,0 +1,1 @@
+{"kb_id":"KB5001111","url":"https://support.microsoft.com/kb/5001111","products":["Windows 10"],"data_source":{"id":"microsoft-cvrf"}}

--- a/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/data/ALSA/2019/ALSA-2019%3A3708.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/data/ALSA/2019/ALSA-2019%3A3708.json
@@ -1,0 +1,469 @@
+{
+	"id": "ALSA-2019:3708",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2019:3708",
+				"title": "Moderate: mariadb:10.3 security and bug fix update",
+				"description": "MariaDB is a multi-user, multi-threaded SQL database server that is binary compatible with MySQL. \n\nThe following packages have been upgraded to a later upstream version: mariadb (10.3.17), galera (25.3.26). (BZ#1701687, BZ#1711265, BZ#1741358)\n\nSecurity Fix(es):\n\n* mysql: InnoDB unspecified vulnerability (CPU Jan 2019) (CVE-2019-2510)\n\n* mysql: Server: DDL unspecified vulnerability (CPU Jan 2019) (CVE-2019-2537)\n\n* mysql: Server: Replication unspecified vulnerability (CPU Apr 2019) (CVE-2019-2614)\n\n* mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2019) (CVE-2019-2627)\n\n* mysql: InnoDB unspecified vulnerability (CPU Apr 2019) (CVE-2019-2628)\n\n* mysql: Server: Pluggable Auth unspecified vulnerability (CPU Jul 2019) (CVE-2019-2737)\n\n* mysql: Server: Security: Privileges unspecified vulnerability (CPU Jul 2019) (CVE-2019-2739)\n\n* mysql: Server: XML unspecified vulnerability (CPU Jul 2019) (CVE-2019-2740)\n\n* mysql: InnoDB unspecified vulnerability (CPU Jul 2019) (CVE-2019-2758)\n\n* mysql: Server: Parser unspecified vulnerability (CPU Jul 2019) (CVE-2019-2805)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the AlmaLinux Release Notes linked from the References section.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Moderate"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2019-3708.html"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2510"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2537"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2614"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2627"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2628"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2737"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2739"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2740"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2758"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2805"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2020-2922"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2021-2007"
+					}
+				],
+				"published": "2019-11-06T04:53:43+09:00",
+				"modified": "2022-04-28T19:46:58+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2019-2510",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2510"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2537",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2537"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2614",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2614"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2627",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2627"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2628",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2628"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2737",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2737"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2739",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2739"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2740",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2740"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2758",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2758"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2805",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2805"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2020-2922",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2020-2922"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2021-2007",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2021-2007"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy",
+											"architectures": [
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy-devel",
+											"architectures": [
+												"i686",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy-devel",
+											"architectures": [
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.3::Judy",
+											"architectures": [
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.3::Judy",
+											"architectures": [
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.5.0+2632+14ced695"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.5.0+2632+14ced695"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.5::Judy",
+											"architectures": [
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2761+593e5e59"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2761+593e5e59"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"fixtures/8/ALSA/2019/ALSA-2019:3708.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
@@ -1,0 +1,367 @@
+{
+	"id": "ALSA-2024:0113",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2024:0113",
+				"title": "Important: kernel security update",
+				"description": "The kernel packages contain the Linux kernel, the core of any Linux operating system.\n\nSecurity Fix(es):\n\n* kernel: use after free in unix_stream_sendpage (CVE-2023-4622)\n* kernel: vmwgfx: reference count issue leads to use-after-free in surface handling (CVE-2023-5633)\n* kernel: netfilter: potential slab-out-of-bound access due to integer underflow (CVE-2023-42753)\n* Kernel: UAF during login when accessing the shost ipaddress (CVE-2023-2162)\n* hw amd: Return Address Predictor vulnerability leading to information disclosure (CVE-2023-20569)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Backport OVS l4 Symmetric Hashing to almalinux-8 (JIRA:AlmaLinux-12746)\n* Unbounded memory usage by TCP for receive buffers (JIRA:AlmaLinux-15096)\n* various kind of guests freeze on rhel 8.8 (JIRA:AlmaLinux-15121)\n* AlmaLinux 8: netfilter: conntrack: Fix gre tunneling over ipv6  (JIRA:AlmaLinux-15259)\n* NFSv4.1 needs to handle ENOENT error from GETDEVICEINFO (JIRA:AlmaLinux-16407)\n* DM multipath showing failed path for an nvme-o-FC LUN when performing I/O operations (JIRA:AlmaLinux-14718)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/errata/RHSA-2024:0113"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2187773"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2207625"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2237760"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2239843"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2245663"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2024-0113.html"
+					}
+				],
+				"published": "2024-01-10T00:00:00Z",
+				"modified": "2024-01-17T10:35:17Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-20569",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2162",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-42753",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-4622",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-5633",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-doc",
+											"architectures": [
+												"noarch"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"vuls-data-raw-alma-errata/8/ALSA/2024/ALSA-2024:0113.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-added/alma-errata/datasource.json
@@ -1,0 +1,1 @@
+{"id":"alma-errata","name":"AlmaLinux Errata"}

--- a/pkg/db/diff/db/testdata/fixtures/target-changed/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-changed/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
@@ -1,0 +1,367 @@
+{
+	"id": "ALSA-2024:0113",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2024:0113",
+				"title": "Important: kernel security update",
+				"description": "The kernel packages contain the Linux kernel, the core of any Linux operating system.\n\nSecurity Fix(es):\n\n* kernel: use after free in unix_stream_sendpage (CVE-2023-4622)\n* kernel: vmwgfx: reference count issue leads to use-after-free in surface handling (CVE-2023-5633)\n* kernel: netfilter: potential slab-out-of-bound access due to integer underflow (CVE-2023-42753)\n* Kernel: UAF during login when accessing the shost ipaddress (CVE-2023-2162)\n* hw amd: Return Address Predictor vulnerability leading to information disclosure (CVE-2023-20569)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Backport OVS l4 Symmetric Hashing to almalinux-8 (JIRA:AlmaLinux-12746)\n* Unbounded memory usage by TCP for receive buffers (JIRA:AlmaLinux-15096)\n* various kind of guests freeze on rhel 8.8 (JIRA:AlmaLinux-15121)\n* AlmaLinux 8: netfilter: conntrack: Fix gre tunneling over ipv6  (JIRA:AlmaLinux-15259)\n* NFSv4.1 needs to handle ENOENT error from GETDEVICEINFO (JIRA:AlmaLinux-16407)\n* DM multipath showing failed path for an nvme-o-FC LUN when performing I/O operations (JIRA:AlmaLinux-14718)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/errata/RHSA-2024:0113"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2187773"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2207625"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2237760"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2239843"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2245663"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2024-0113.html"
+					}
+				],
+				"published": "2024-01-10T00:00:00Z",
+				"modified": "2024-01-17T10:35:17Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-20569",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2162",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-42753",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-4622",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-5633",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-999.99.99.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-doc",
+											"architectures": [
+												"noarch"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"vuls-data-raw-alma-errata/8/ALSA/2024/ALSA-2024:0113.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/target-changed/alma-errata/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-changed/alma-errata/datasource.json
@@ -1,0 +1,1 @@
+{"id":"alma-errata","name":"AlmaLinux Errata"}

--- a/pkg/db/diff/db/testdata/fixtures/target-replaced/alma-errata/data/ALSA/2019/ALSA-2019%3A3708.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-replaced/alma-errata/data/ALSA/2019/ALSA-2019%3A3708.json
@@ -1,0 +1,469 @@
+{
+	"id": "ALSA-2019:3708",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2019:3708",
+				"title": "Moderate: mariadb:10.3 security and bug fix update",
+				"description": "MariaDB is a multi-user, multi-threaded SQL database server that is binary compatible with MySQL. \n\nThe following packages have been upgraded to a later upstream version: mariadb (10.3.17), galera (25.3.26). (BZ#1701687, BZ#1711265, BZ#1741358)\n\nSecurity Fix(es):\n\n* mysql: InnoDB unspecified vulnerability (CPU Jan 2019) (CVE-2019-2510)\n\n* mysql: Server: DDL unspecified vulnerability (CPU Jan 2019) (CVE-2019-2537)\n\n* mysql: Server: Replication unspecified vulnerability (CPU Apr 2019) (CVE-2019-2614)\n\n* mysql: Server: Security: Privileges unspecified vulnerability (CPU Apr 2019) (CVE-2019-2627)\n\n* mysql: InnoDB unspecified vulnerability (CPU Apr 2019) (CVE-2019-2628)\n\n* mysql: Server: Pluggable Auth unspecified vulnerability (CPU Jul 2019) (CVE-2019-2737)\n\n* mysql: Server: Security: Privileges unspecified vulnerability (CPU Jul 2019) (CVE-2019-2739)\n\n* mysql: Server: XML unspecified vulnerability (CPU Jul 2019) (CVE-2019-2740)\n\n* mysql: InnoDB unspecified vulnerability (CPU Jul 2019) (CVE-2019-2758)\n\n* mysql: Server: Parser unspecified vulnerability (CPU Jul 2019) (CVE-2019-2805)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nAdditional Changes:\n\nFor detailed information on changes in this release, see the AlmaLinux Release Notes linked from the References section.",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Moderate"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2019-3708.html"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2510"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2537"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2614"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2627"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2628"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2737"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2739"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2740"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2758"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2805"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2020-2922"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2021-2007"
+					}
+				],
+				"published": "2019-11-06T04:53:43+09:00",
+				"modified": "2022-04-28T19:46:58+09:00"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2019-2510",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2510"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2537",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2537"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2614",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2614"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2627",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2627"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2628",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2628"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2737",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2737"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2739",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2739"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2740",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2740"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2758",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2758"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2019-2805",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2019-2805"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2020-2922",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2020-2922"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2021-2007",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://vulners.com/cve/CVE-2021-2007"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy",
+											"architectures": [
+												"i686"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy-devel",
+											"architectures": [
+												"i686",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.3.0+2028+5e3224e9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb-devel:10.3::Judy-devel",
+											"architectures": [
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.3::Judy",
+											"architectures": [
+												"ppc64le"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2867+72759d2f"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.3::Judy",
+											"architectures": [
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.5.0+2632+14ced695"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.5.0+2632+14ced695"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "mariadb:10.5::Judy",
+											"architectures": [
+												"aarch64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:1.0.5-18.module_el8.6.0+2761+593e5e59"
+											}
+										],
+										"fixed": [
+											"0:1.0.5-18.module_el8.6.0+2761+593e5e59"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"fixtures/8/ALSA/2019/ALSA-2019:3708.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/target-replaced/alma-errata/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-replaced/alma-errata/datasource.json
@@ -1,0 +1,1 @@
+{"id":"alma-errata","name":"AlmaLinux Errata"}

--- a/pkg/db/diff/db/testdata/fixtures/target-same/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-same/alma-errata/data/ALSA/2024/ALSA-2024%3A0113.json
@@ -1,0 +1,367 @@
+{
+	"id": "ALSA-2024:0113",
+	"advisories": [
+		{
+			"content": {
+				"id": "ALSA-2024:0113",
+				"title": "Important: kernel security update",
+				"description": "The kernel packages contain the Linux kernel, the core of any Linux operating system.\n\nSecurity Fix(es):\n\n* kernel: use after free in unix_stream_sendpage (CVE-2023-4622)\n* kernel: vmwgfx: reference count issue leads to use-after-free in surface handling (CVE-2023-5633)\n* kernel: netfilter: potential slab-out-of-bound access due to integer underflow (CVE-2023-42753)\n* Kernel: UAF during login when accessing the shost ipaddress (CVE-2023-2162)\n* hw amd: Return Address Predictor vulnerability leading to information disclosure (CVE-2023-20569)\n\nFor more details about the security issue(s), including the impact, a CVSS score, acknowledgments, and other related information, refer to the CVE page(s) listed in the References section.\n\nBug Fix(es):\n\n* Backport OVS l4 Symmetric Hashing to almalinux-8 (JIRA:AlmaLinux-12746)\n* Unbounded memory usage by TCP for receive buffers (JIRA:AlmaLinux-15096)\n* various kind of guests freeze on rhel 8.8 (JIRA:AlmaLinux-15121)\n* AlmaLinux 8: netfilter: conntrack: Fix gre tunneling over ipv6  (JIRA:AlmaLinux-15259)\n* NFSv4.1 needs to handle ENOENT error from GETDEVICEINFO (JIRA:AlmaLinux-16407)\n* DM multipath showing failed path for an nvme-o-FC LUN when performing I/O operations (JIRA:AlmaLinux-14718)",
+				"severity": [
+					{
+						"type": "vendor",
+						"source": "errata.almalinux.org",
+						"vendor": "Important"
+					}
+				],
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/errata/RHSA-2024:0113"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2187773"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2207625"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2237760"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2239843"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://bugzilla.redhat.com/2245663"
+					},
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://errata.almalinux.org/8/ALSA-2024-0113.html"
+					}
+				],
+				"published": "2024-01-10T00:00:00Z",
+				"modified": "2024-01-17T10:35:17Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2023-20569",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-20569"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-2162",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-2162"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-42753",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-42753"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-4622",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-4622"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		},
+		{
+			"content": {
+				"id": "CVE-2023-5633",
+				"references": [
+					{
+						"source": "errata.almalinux.org",
+						"url": "https://access.redhat.com/security/cve/CVE-2023-5633"
+					}
+				]
+			},
+			"segments": [
+				{
+					"ecosystem": "alma:8"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "alma:8",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterions": [
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-debug",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-devel",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-doc",
+											"architectures": [
+												"noarch"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "kernel-modules",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							},
+							{
+								"type": "version",
+								"version": {
+									"vulnerable": true,
+									"fix_status": {
+										"class": "fixed"
+									},
+									"package": {
+										"type": "binary",
+										"binary": {
+											"name": "perf",
+											"architectures": [
+												"aarch64",
+												"ppc64le",
+												"s390x",
+												"x86_64"
+											]
+										}
+									},
+									"affected": {
+										"type": "rpm",
+										"range": [
+											{
+												"lt": "0:4.18.0-513.11.1.el8_9"
+											}
+										],
+										"fixed": [
+											"0:4.18.0-513.11.1.el8_9"
+										]
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "alma-errata",
+		"raws": [
+			"vuls-data-raw-alma-errata/8/ALSA/2024/ALSA-2024:0113.json"
+		]
+	}
+}

--- a/pkg/db/diff/db/testdata/fixtures/target-same/alma-errata/datasource.json
+++ b/pkg/db/diff/db/testdata/fixtures/target-same/alma-errata/datasource.json
@@ -1,0 +1,1 @@
+{"id":"alma-errata","name":"AlmaLinux Errata"}

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -181,7 +181,7 @@ func detectAll(baselineBin, baselineDB, targetBin, targetDB string, files map[st
 	}
 
 	if err := g.Wait(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "vuls0 detection")
 	}
 	close(resChan)
 
@@ -204,7 +204,7 @@ func detectAll(baselineBin, baselineDB, targetBin, targetDB string, files map[st
 }
 
 // runVuls0Report runs vuls0 report on a single scan result file and returns detected CVE IDs.
-func runVuls0Report(ctx context.Context, binary, dbpath, filePath string) ([]string, error) {
+func runVuls0Report(ctx context.Context, binary, dbpath, scanResultPath string) ([]string, error) {
 	tmpDir, err := os.MkdirTemp("", "diff-vuls0-*")
 	if err != nil {
 		return nil, errors.Wrap(err, "mkdtemp")
@@ -232,11 +232,11 @@ skipUpdate = true
 		return nil, errors.Wrapf(err, "mkdir %s", tsDir)
 	}
 
-	dst := filepath.Join(tsDir, filepath.Base(filePath))
+	dst := filepath.Join(tsDir, filepath.Base(scanResultPath))
 	if err := func() error {
-		in, err := os.Open(filePath)
+		in, err := os.Open(scanResultPath)
 		if err != nil {
-			return errors.Wrapf(err, "open %s", filePath)
+			return errors.Wrapf(err, "open %s", scanResultPath)
 		}
 		defer in.Close()
 
@@ -247,11 +247,11 @@ skipUpdate = true
 		defer out.Close()
 
 		if _, err := io.Copy(out, in); err != nil {
-			return errors.Wrapf(err, "copy %s to %s", filePath, dst)
+			return errors.Wrapf(err, "copy %s to %s", scanResultPath, dst)
 		}
 		return nil
 	}(); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "copy scan result file")
 	}
 
 	cmd := exec.CommandContext(ctx, binary,
@@ -292,37 +292,29 @@ skipUpdate = true
 // therefore invisible. This is sufficient for regression detection (missing or
 // extra CVEs), but not for validating data source migrations where IDs stay
 // the same but metadata differs.
-func computeDiffs(detections map[string]FileDiff, changeRateThreshold float64) map[string]FileDiff {
-	result := make(map[string]FileDiff, len(detections))
-	for name, d := range detections {
-		added := subtract(d.TargetIDs, d.BaselineIDs)
-		removed := subtract(d.BaselineIDs, d.TargetIDs)
+func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64) map[string]FileDiff {
+	for name, d := range ds {
+		d.Added = subtract(d.TargetIDs, d.BaselineIDs)
+		d.Removed = subtract(d.BaselineIDs, d.TargetIDs)
 
 		// changeRate can exceed 100% when additions outnumber baseline entries.
 		// This is intentional — capping at 100 would hide the magnitude of large additions.
-		changeRate := func() float64 {
+		d.ChangeRate = func() float64 {
 			switch {
 			case len(d.BaselineIDs) > 0:
-				return float64(len(added)+len(removed)) / float64(len(d.BaselineIDs)) * 100
-			case len(added)+len(removed) > 0:
+				return float64(len(d.Added)+len(d.Removed)) / float64(len(d.BaselineIDs)) * 100
+			case len(d.Added)+len(d.Removed) > 0:
 				return 100
 			default:
 				return 0
 			}
 		}()
+		d.Pass = d.ChangeRate <= changeRateThreshold
 
-		result[name] = FileDiff{
-			Name:        d.Name,
-			BaselineIDs: d.BaselineIDs,
-			TargetIDs:   d.TargetIDs,
-			Added:       added,
-			Removed:     removed,
-			ChangeRate:  changeRate,
-			Pass:        changeRate <= changeRateThreshold,
-		}
+		ds[name] = d
 	}
 
-	return result
+	return ds
 }
 
 // subtract returns elements in a that are not in b (i.e. a \ b).

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -1,0 +1,350 @@
+package detection
+
+import (
+	"context"
+	"encoding/json/v2"
+	"fmt"
+	"io"
+	"log/slog"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+)
+
+type options struct {
+	changeRateThreshold float64
+	debug               bool
+	writer              io.Writer
+	detectFunc          func(baselineBin, baselineDB, targetBin, targetDB string, files map[string]string) (map[string]FileDiff, error)
+}
+
+type Option interface {
+	apply(*options)
+}
+
+type changeRateThresholdOption float64
+
+func (o changeRateThresholdOption) apply(opts *options) {
+	opts.changeRateThreshold = float64(o)
+}
+func WithChangeRateThreshold(r float64) Option {
+	return changeRateThresholdOption(r)
+}
+
+type debugOption bool
+
+func (o debugOption) apply(opts *options) {
+	opts.debug = bool(o)
+}
+func WithDebug(d bool) Option {
+	return debugOption(d)
+}
+
+type writerOption struct{ w io.Writer }
+
+func (o writerOption) apply(opts *options) {
+	opts.writer = o.w
+}
+func WithWriter(w io.Writer) Option {
+	return writerOption{w: w}
+}
+
+// FileDiff holds the comparison result for a single scan result file.
+type FileDiff struct {
+	Name        string
+	BaselineIDs []string
+	TargetIDs   []string
+	Added       []string
+	Removed     []string
+	ChangeRate  float64
+	Pass        bool
+}
+
+// Diff compares detection results between baseline and target pairs of (binary, DB).
+func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, opts ...Option) error {
+	o := &options{
+		changeRateThreshold: 0,
+		writer:              os.Stdout,
+		detectFunc:          detectAll,
+	}
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+
+	if o.debug {
+		slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
+	}
+
+	files, err := listScanResults(scanResultsDir)
+	if err != nil {
+		return errors.Wrap(err, "list scan result files")
+	}
+
+	slog.Info("Starting detection diff",
+		"files", len(files),
+		"baseline-binary", baselineBin, "baseline-db", baselineDB,
+		"target-binary", targetBin, "target-db", targetDB)
+
+	diffm, err := o.detectFunc(baselineBin, baselineDB, targetBin, targetDB, files)
+	if err != nil {
+		return errors.Wrap(err, "detect")
+	}
+
+	diffm = computeDiffs(diffm, o.changeRateThreshold)
+
+	pass, err := generateReport(o.writer, diffm, o.changeRateThreshold)
+	if err != nil {
+		return errors.Wrap(err, "generate report")
+	}
+	if !pass {
+		return errors.Errorf("diff failed: change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
+	}
+	return nil
+}
+
+// listScanResults lists *.json files in the directory.
+// Returns a map from file name (without .json extension) to full path.
+func listScanResults(dir string) (map[string]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrapf(err, "read dir %s", dir)
+	}
+	files := make(map[string]string)
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		name := strings.TrimSuffix(e.Name(), ".json")
+		files[name] = filepath.Join(dir, e.Name())
+	}
+	if len(files) == 0 {
+		return nil, errors.Errorf("no *.json files found in %s", dir)
+	}
+	return files, nil
+}
+
+// detectAll runs vuls0 detection for all scan result files against both
+// baseline and target (binary, DB) pairs in a single worker pool.
+func detectAll(baselineBin, baselineDB, targetBin, targetDB string, files map[string]string) (map[string]FileDiff, error) {
+	type task struct {
+		role   string
+		name   string
+		binary string
+		dbpath string
+		path   string
+	}
+
+	tasks := make([]task, 0, len(files)*2)
+	for name, p := range files {
+		tasks = append(tasks,
+			task{role: "baseline", name: name, binary: baselineBin, dbpath: baselineDB, path: p},
+			task{role: "target", name: name, binary: targetBin, dbpath: targetDB, path: p},
+		)
+	}
+
+	type result struct {
+		role string
+		name string
+		ids  []string
+	}
+
+	total := len(tasks)
+	resChan := make(chan result, total)
+
+	workers := min(runtime.NumCPU(), total)
+	slog.Info("Starting vuls0 detection", "files", len(files), "tasks", total, "workers", workers)
+
+	g, ctx := errgroup.WithContext(context.TODO())
+	g.SetLimit(workers)
+
+	for _, t := range tasks {
+		g.Go(func() error {
+			slog.Debug("vuls0 detect start", "role", t.role, "name", t.name)
+
+			ids, err := runVuls0Report(ctx, t.binary, t.dbpath, t.path)
+			if err != nil {
+				return errors.Wrapf(err, "vuls0 report %s/%s", t.role, t.name)
+			}
+			resChan <- result{role: t.role, name: t.name, ids: ids}
+			slog.Debug("vuls0 detect done", "role", t.role, "name", t.name, "cves", len(ids))
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
+	close(resChan)
+
+	diffm := make(map[string]FileDiff, len(files))
+	for name := range files {
+		diffm[name] = FileDiff{Name: name}
+	}
+	for r := range resChan {
+		d := diffm[r.name]
+		switch r.role {
+		case "baseline":
+			d.BaselineIDs = r.ids
+		case "target":
+			d.TargetIDs = r.ids
+		}
+		diffm[r.name] = d
+	}
+
+	return diffm, nil
+}
+
+// runVuls0Report runs vuls0 report on a single scan result file and returns detected CVE IDs.
+func runVuls0Report(ctx context.Context, binary, dbpath, filePath string) ([]string, error) {
+	tmpDir, err := os.MkdirTemp("", "diff-vuls0-*")
+	if err != nil {
+		return nil, errors.Wrap(err, "mkdtemp")
+	}
+	defer os.RemoveAll(tmpDir) //nolint:errcheck
+
+	// NOTE: Only [vuls2] is configured; legacy data sources (gost, go-cve-dictionary,
+	// etc.) are not included. Detections from legacy sources will not appear in either
+	// baseline or target runs.
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.toml"), fmt.Appendf(nil,
+		`
+[servers]
+[servers.localhost]
+host = "localhost"
+
+[vuls2]
+path = %q
+skipUpdate = true
+`, dbpath), 0o644); err != nil {
+		return nil, errors.Wrapf(err, "write config %s", filepath.Join(tmpDir, "config.toml"))
+	}
+
+	tsDir := filepath.Join(tmpDir, "results", "2000-01-01T00-00-00+0000")
+	if err := os.MkdirAll(tsDir, 0o755); err != nil {
+		return nil, errors.Wrapf(err, "mkdir %s", tsDir)
+	}
+
+	dst := filepath.Join(tsDir, filepath.Base(filePath))
+	if err := func() error {
+		in, err := os.Open(filePath)
+		if err != nil {
+			return errors.Wrapf(err, "open %s", filePath)
+		}
+		defer in.Close()
+
+		out, err := os.Create(dst)
+		if err != nil {
+			return errors.Wrapf(err, "create %s", dst)
+		}
+		defer out.Close()
+
+		if _, err := io.Copy(out, in); err != nil {
+			return errors.Wrapf(err, "copy %s to %s", filePath, dst)
+		}
+		return nil
+	}(); err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, binary,
+		"report",
+		"-config", filepath.Join(tmpDir, "config.toml"),
+		"-results-dir", filepath.Join(tmpDir, "results"),
+		"-refresh-cve",
+		"-format-one-line-text",
+		"2000-01-01T00-00-00+0000",
+	)
+	cmd.Dir = tmpDir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, errors.Wrapf(err, "vuls0 report: %s", tailBytes(output, 4096))
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		return nil, errors.Wrapf(err, "open %s", dst)
+	}
+	defer f.Close()
+
+	var sr struct {
+		ScannedCves map[string]struct{} `json:"scannedCves"`
+	}
+	if err := json.UnmarshalRead(f, &sr); err != nil {
+		return nil, errors.Wrapf(err, "decode %s", dst)
+	}
+
+	return slices.Collect(maps.Keys(sr.ScannedCves)), nil
+}
+
+// computeDiffs computes diffs per file by comparing CVE ID sets.
+//
+// Only CVE IDs are compared; per-CVE content (confidence, affected packages,
+// CVSS, exploit/KEV metadata, etc.) is not diffed. Content-only changes are
+// therefore invisible. This is sufficient for regression detection (missing or
+// extra CVEs), but not for validating data source migrations where IDs stay
+// the same but metadata differs.
+func computeDiffs(detections map[string]FileDiff, changeRateThreshold float64) map[string]FileDiff {
+	result := make(map[string]FileDiff, len(detections))
+	for name, d := range detections {
+		added := subtract(d.TargetIDs, d.BaselineIDs)
+		removed := subtract(d.BaselineIDs, d.TargetIDs)
+
+		// changeRate can exceed 100% when additions outnumber baseline entries.
+		// This is intentional — capping at 100 would hide the magnitude of large additions.
+		changeRate := func() float64 {
+			switch {
+			case len(d.BaselineIDs) > 0:
+				return float64(len(added)+len(removed)) / float64(len(d.BaselineIDs)) * 100
+			case len(added)+len(removed) > 0:
+				return 100
+			default:
+				return 0
+			}
+		}()
+
+		result[name] = FileDiff{
+			Name:        d.Name,
+			BaselineIDs: d.BaselineIDs,
+			TargetIDs:   d.TargetIDs,
+			Added:       added,
+			Removed:     removed,
+			ChangeRate:  changeRate,
+			Pass:        changeRate <= changeRateThreshold,
+		}
+	}
+
+	return result
+}
+
+// subtract returns elements in a that are not in b (i.e. a \ b).
+func subtract(a, b []string) []string {
+	bSet := make(map[string]struct{}, len(b))
+	for _, v := range b {
+		bSet[v] = struct{}{}
+	}
+	var diff []string
+	for _, v := range a {
+		if _, ok := bSet[v]; !ok {
+			diff = append(diff, v)
+		}
+	}
+	return diff
+}
+
+// tailBytes returns the trailing max bytes of b, prefixed with a truncation
+// marker when b is longer than max. Used to keep error messages bounded.
+func tailBytes(b []byte, max int) string {
+	if len(b) <= max {
+		return string(b)
+	}
+	return "...[truncated]..." + string(b[len(b)-max:])
+}

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -13,47 +13,60 @@ import (
 )
 
 func TestSubtract(t *testing.T) {
+	type args struct {
+		a []string
+		b []string
+	}
 	tests := []struct {
 		name string
-		a    []string
-		b    []string
+		args args
 		want []string
 	}{
 		{
 			name: "no diff",
-			a:    []string{"CVE-2026-0001", "CVE-2026-0002"},
-			b:    []string{"CVE-2026-0001", "CVE-2026-0002"},
+			args: args{
+				a: []string{"CVE-2026-0001", "CVE-2026-0002"},
+				b: []string{"CVE-2026-0001", "CVE-2026-0002"},
+			},
 			want: nil,
 		},
 		{
 			name: "a has extras",
-			a:    []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-			b:    []string{"CVE-2026-0001"},
+			args: args{
+				a: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+				b: []string{"CVE-2026-0001"},
+			},
 			want: []string{"CVE-2026-0002", "CVE-2026-0003"},
 		},
 		{
 			name: "b has extras",
-			a:    []string{"CVE-2026-0001"},
-			b:    []string{"CVE-2026-0001", "CVE-2026-0002"},
+			args: args{
+				a: []string{"CVE-2026-0001"},
+				b: []string{"CVE-2026-0001", "CVE-2026-0002"},
+			},
 			want: nil,
 		},
 		{
 			name: "empty a",
-			a:    nil,
-			b:    []string{"CVE-2026-0001"},
+			args: args{
+				a: nil,
+				b: []string{"CVE-2026-0001"},
+			},
 			want: nil,
 		},
 		{
 			name: "empty b",
-			a:    []string{"CVE-2026-0001"},
-			b:    nil,
+			args: args{
+				a: []string{"CVE-2026-0001"},
+				b: nil,
+			},
 			want: []string{"CVE-2026-0001"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detection.Subtract(tt.a, tt.b)
+			got := detection.Subtract(tt.args.a, tt.args.b)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("Subtract() mismatch (-want +got):\n%s", diff)
 			}
@@ -329,7 +342,7 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: Detection
 
-**Result**: FAIL
+**Result**: **FAIL**
 **Change Rate Threshold**: 10.0%
 **Change Rate Max**:       75.0% (ubuntu_22.04)
 
@@ -436,49 +449,60 @@ func TestDiff(t *testing.T) {
 
 	emptyDir := t.TempDir()
 
-	tests := []struct {
-		name                string
+	type args struct {
 		dir                 string
 		detectFunc          detection.DetectFunc
 		changeRateThreshold float64
-		wantErr             bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
-			name:                "fail on exceeded change rate",
-			dir:                 scanDir,
-			detectFunc:          fakeDetect,
-			changeRateThreshold: 10,
-			wantErr:             true,
+			name: "fail on exceeded change rate",
+			args: args{
+				dir:                 scanDir,
+				detectFunc:          fakeDetect,
+				changeRateThreshold: 10,
+			},
+			wantErr: true,
 		},
 		{
-			name:                "pass within threshold",
-			dir:                 scanDir,
-			detectFunc:          fakeDetect,
-			changeRateThreshold: 100,
-			wantErr:             false,
+			name: "pass within threshold",
+			args: args{
+				dir:                 scanDir,
+				detectFunc:          fakeDetect,
+				changeRateThreshold: 100,
+			},
+			wantErr: false,
 		},
 		{
-			name:                "detect error propagated",
-			dir:                 scanDir,
-			detectFunc:          fakeDetectErr,
-			changeRateThreshold: 10,
-			wantErr:             true,
+			name: "detect error propagated",
+			args: args{
+				dir:                 scanDir,
+				detectFunc:          fakeDetectErr,
+				changeRateThreshold: 10,
+			},
+			wantErr: true,
 		},
 		{
-			name:                "no scan results error",
-			dir:                 emptyDir,
-			detectFunc:          fakeDetect,
-			changeRateThreshold: 10,
-			wantErr:             true,
+			name: "no scan results error",
+			args: args{
+				dir:                 emptyDir,
+				detectFunc:          fakeDetect,
+				changeRateThreshold: 10,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := detection.Diff(
-				tt.dir, "baseline.db", "vuls0", "target.db", "vuls0",
-				detection.WithChangeRateThreshold(tt.changeRateThreshold),
+				tt.args.dir, "baseline.db", "vuls0", "target.db", "vuls0",
+				detection.WithChangeRateThreshold(tt.args.changeRateThreshold),
 				detection.WithWriter(&bytes.Buffer{}),
-				detection.WithDetectFunc(tt.detectFunc),
+				detection.WithDetectFunc(tt.args.detectFunc),
 			)
 
 			if (err != nil) != tt.wantErr {

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -1,0 +1,489 @@
+package detection_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/MaineK00n/vuls2/pkg/db/diff/detection"
+)
+
+func TestSubtract(t *testing.T) {
+	tests := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{
+			name: "no diff",
+			a:    []string{"CVE-2026-0001", "CVE-2026-0002"},
+			b:    []string{"CVE-2026-0001", "CVE-2026-0002"},
+			want: nil,
+		},
+		{
+			name: "a has extras",
+			a:    []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+			b:    []string{"CVE-2026-0001"},
+			want: []string{"CVE-2026-0002", "CVE-2026-0003"},
+		},
+		{
+			name: "b has extras",
+			a:    []string{"CVE-2026-0001"},
+			b:    []string{"CVE-2026-0001", "CVE-2026-0002"},
+			want: nil,
+		},
+		{
+			name: "empty a",
+			a:    nil,
+			b:    []string{"CVE-2026-0001"},
+			want: nil,
+		},
+		{
+			name: "empty b",
+			a:    []string{"CVE-2026-0001"},
+			b:    nil,
+			want: []string{"CVE-2026-0001"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detection.Subtract(tt.a, tt.b)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Subtract() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestComputeDiffs(t *testing.T) {
+	type args struct {
+		detections          map[string]detection.FileDiff
+		changeRateThreshold float64
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]detection.FileDiff
+	}{
+		{
+			name: "no change",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					ChangeRate:  0,
+					Pass:        true,
+				},
+			},
+		},
+		{
+			name: "small change within limit",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name: "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+							"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0010"},
+						TargetIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+							"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0011"},
+					},
+				},
+				changeRateThreshold: 25,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name: "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+						"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0010"},
+					TargetIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+						"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0011"},
+					Added:      []string{"CVE-2026-0011"},
+					Removed:    []string{"CVE-2026-0010"},
+					ChangeRate: 20,
+					Pass:       true,
+				},
+			},
+		},
+		{
+			name: "large change exceeds limit",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"ubuntu_22.04": {
+						Name:        "ubuntu_22.04",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"ubuntu_22.04": {
+					Name:        "ubuntu_22.04",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+					TargetIDs:   []string{"CVE-2026-0001"},
+					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+					ChangeRate:  75,
+					Pass:        false,
+				},
+			},
+		},
+		{
+			name: "large addition exceeds limit",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"ubuntu_22.04": {
+						Name:        "ubuntu_22.04",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"ubuntu_22.04": {
+					Name:        "ubuntu_22.04",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
+					Added:       []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
+					ChangeRate:  200,
+					Pass:        false,
+				},
+			},
+		},
+		{
+			name: "empty baseline triggers 100% change",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					Added:       []string{"CVE-2026-0001", "CVE-2026-0002"},
+					ChangeRate:  100,
+					Pass:        false,
+				},
+			},
+		},
+		{
+			name: "both empty avoids zero division",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{},
+						TargetIDs:   []string{},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{},
+					TargetIDs:   []string{},
+					ChangeRate:  0,
+					Pass:        true,
+				},
+			},
+		},
+		{
+			name: "target all removed",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					},
+					"ubuntu_22.04": {
+						Name:        "ubuntu_22.04",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+						TargetIDs:   nil,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					ChangeRate:  0,
+					Pass:        true,
+				},
+				"ubuntu_22.04": {
+					Name:        "ubuntu_22.04",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					Removed:     []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					ChangeRate:  100,
+					Pass:        false,
+				},
+			},
+		},
+		{
+			name: "multiple files mixed",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					},
+					"ubuntu_22.04": {
+						Name:        "ubuntu_22.04",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					ChangeRate:  0,
+					Pass:        true,
+				},
+				"ubuntu_22.04": {
+					Name:        "ubuntu_22.04",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+					TargetIDs:   []string{"CVE-2026-0001"},
+					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+					ChangeRate:  75,
+					Pass:        false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := detection.ComputeDiffs(tt.args.detections, tt.args.changeRateThreshold)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ComputeDiffs() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGenerateReport(t *testing.T) {
+	type args struct {
+		diffs               map[string]detection.FileDiff
+		changeRateThreshold float64
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantPass   bool
+		wantReport string
+	}{
+		{
+			name: "fail with details",
+			args: args{
+				diffs: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+						ChangeRate:  0,
+						Pass:        true,
+					},
+					"ubuntu_22.04": {
+						Name:        "ubuntu_22.04",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+						Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+						ChangeRate:  75.0,
+						Pass:        false,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: Detection
+
+**Result**: FAIL
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       75.0% (ubuntu_22.04)
+
+## Summary
+
+| Name | Baseline | Target | Added | Removed | Change Rate | Result |
+|------|----------|--------|-------|---------|-------------|--------|
+| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% | **FAIL** |
+| redhat_9 | 2 | 2 | 0 | 0 | 0.0% | PASS |
+
+## Details (FAIL files)
+
+### ubuntu_22.04
+
+#### Removed IDs (3)
+
+- CVE-2026-0002
+- CVE-2026-0003
+- CVE-2026-0004
+
+`,
+		},
+		{
+			name: "all pass",
+			args: args{
+				diffs: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+						ChangeRate:  0,
+						Pass:        true,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: true,
+			wantReport: `# Diff Report: Detection
+
+**Result**: PASS
+**Change Rate Threshold**: 10.0%
+**Change Rate Max**:       0.0%
+
+## Summary
+
+| Name | Baseline | Target | Added | Removed | Change Rate | Result |
+|------|----------|--------|-------|---------|-------------|--------|
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | PASS |
+
+`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			gotPass, err := detection.GenerateReport(&buf, tt.args.diffs, tt.args.changeRateThreshold)
+			if err != nil {
+				t.Fatalf("GenerateReport() error = %v", err)
+			}
+			if gotPass != tt.wantPass {
+				t.Errorf("GenerateReport() pass = %v, want %v", gotPass, tt.wantPass)
+			}
+			got := buf.String()
+			if diff := cmp.Diff(tt.wantReport, got); diff != "" {
+				t.Errorf("GenerateReport() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestDiff(t *testing.T) {
+	// Prepare a scan results directory with two dummy JSON files.
+	scanDir := t.TempDir()
+	for _, name := range []string{"redhat_9.json", "ubuntu_2204.json"} {
+		if err := os.WriteFile(filepath.Join(scanDir, name), []byte(`{}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fakeDetect := func(_, _, _, _ string, files map[string]string) (map[string]detection.FileDiff, error) {
+		result := make(map[string]detection.FileDiff, len(files))
+		for name := range files {
+			switch name {
+			case "redhat_9":
+				result[name] = detection.FileDiff{
+					Name:        name,
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+				}
+			case "ubuntu_2204":
+				result[name] = detection.FileDiff{
+					Name:        name,
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					TargetIDs:   []string{"CVE-2026-0001"},
+				}
+			}
+		}
+		return result, nil
+	}
+
+	fakeDetectErr := func(_, _, _, _ string, _ map[string]string) (map[string]detection.FileDiff, error) {
+		return nil, errors.New("vuls0 crashed")
+	}
+
+	emptyDir := t.TempDir()
+
+	tests := []struct {
+		name                string
+		dir                 string
+		detectFunc          detection.DetectFunc
+		changeRateThreshold float64
+		wantErr             bool
+	}{
+		{
+			name:                "fail on exceeded change rate",
+			dir:                 scanDir,
+			detectFunc:          fakeDetect,
+			changeRateThreshold: 10,
+			wantErr:             true,
+		},
+		{
+			name:                "pass within threshold",
+			dir:                 scanDir,
+			detectFunc:          fakeDetect,
+			changeRateThreshold: 100,
+			wantErr:             false,
+		},
+		{
+			name:                "detect error propagated",
+			dir:                 scanDir,
+			detectFunc:          fakeDetectErr,
+			changeRateThreshold: 10,
+			wantErr:             true,
+		},
+		{
+			name:                "no scan results error",
+			dir:                 emptyDir,
+			detectFunc:          fakeDetect,
+			changeRateThreshold: 10,
+			wantErr:             true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := detection.Diff(
+				tt.dir, "baseline.db", "vuls0", "target.db", "vuls0",
+				detection.WithChangeRateThreshold(tt.changeRateThreshold),
+				detection.WithWriter(&bytes.Buffer{}),
+				detection.WithDetectFunc(tt.detectFunc),
+			)
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Diff() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -342,11 +342,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: false,
 			wantReport: `# Diff Report: Detection
 
-**Result**: **FAIL**
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       75.0% (ubuntu_22.04)
-
 ## Summary
+
+**Result**: **FAIL** (Change Rate Threshold: 10.0%)
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|
@@ -355,7 +353,7 @@ func TestGenerateReport(t *testing.T) {
 
 ## Details (FAIL files)
 
-### ubuntu_22.04
+### ubuntu_22.04 (75.0%)
 
 #### Removed IDs (3)
 
@@ -382,11 +380,9 @@ func TestGenerateReport(t *testing.T) {
 			wantPass: true,
 			wantReport: `# Diff Report: Detection
 
-**Result**: PASS
-**Change Rate Threshold**: 10.0%
-**Change Rate Max**:       0.0%
-
 ## Summary
+
+**Result**: PASS (Change Rate Threshold: 10.0%)
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|

--- a/pkg/db/diff/detection/export_test.go
+++ b/pkg/db/diff/detection/export_test.go
@@ -1,0 +1,19 @@
+package detection
+
+type DetectFunc = func(baselineBin, baselineDB, targetBin, targetDB string, files map[string]string) (map[string]FileDiff, error)
+
+func WithDetectFunc(f DetectFunc) Option {
+	return detectFuncOption{f: f}
+}
+
+type detectFuncOption struct{ f DetectFunc }
+
+func (o detectFuncOption) apply(opts *options) {
+	opts.detectFunc = o.f
+}
+
+var (
+	Subtract       = subtract
+	ComputeDiffs   = computeDiffs
+	GenerateReport = generateReport
+)

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -28,15 +28,13 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
 
-**Result**: %s
-**Change Rate Threshold**: %.1f%%
-**Change Rate Max**:       %s
-
 ## Summary
+
+**Result**: %s (Change Rate Threshold: %.1f%%)
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|
-`, resultLabel(pass), changeRateThreshold, formatMax(diffs[0].ChangeRate, diffs[0].Name)); err != nil {
+`, resultLabel(pass), changeRateThreshold); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 
@@ -64,7 +62,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 			return false, errors.Wrap(err, "write details header")
 		}
 		for _, d := range failDiffs {
-			if _, err := fmt.Fprintf(w, "### %s\n\n", d.Name); err != nil {
+			if _, err := fmt.Fprintf(w, "### %s (%.1f%%)\n\n", d.Name, d.ChangeRate); err != nil {
 				return false, errors.Wrapf(err, "write file header %s", d.Name)
 			}
 			if len(d.Added) > 0 {
@@ -83,15 +81,6 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	}
 
 	return pass, nil
-}
-
-// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
-// the name part when the rate is 0 (no non-zero change exists).
-func formatMax(rate float64, name string) string {
-	if rate == 0 {
-		return fmt.Sprintf("%.1f%%", rate)
-	}
-	return fmt.Sprintf("%.1f%% (%s)", rate, name)
 }
 
 func resultLabel(pass bool) string {

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -81,6 +81,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 				if _, err := fmt.Fprintf(w, "#### Added IDs (%d)\n\n", len(d.Added)); err != nil {
 					return false, errors.Wrapf(err, "write added header %s", d.Name)
 				}
+				slices.Sort(d.Added)
 				for _, id := range d.Added {
 					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
 						return false, errors.Wrapf(err, "write added ID %s", d.Name)
@@ -94,6 +95,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 				if _, err := fmt.Fprintf(w, "#### Removed IDs (%d)\n\n", len(d.Removed)); err != nil {
 					return false, errors.Wrapf(err, "write removed header %s", d.Name)
 				}
+				slices.Sort(d.Removed)
 				for _, id := range d.Removed {
 					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
 						return false, errors.Wrapf(err, "write removed ID %s", d.Name)

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -13,6 +13,10 @@ import (
 // generateReport writes a Markdown report for detection diff to w.
 // It returns whether all files passed and any write error.
 func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold float64) (bool, error) {
+	if len(diffm) == 0 {
+		return true, errors.New("no files to compare")
+	}
+
 	diffs := slices.Collect(maps.Values(diffm))
 	slices.SortFunc(diffs, func(a, b FileDiff) int {
 		return cmp.Or(

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -20,11 +20,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 			cmp.Compare(a.Name, b.Name),
 		)
 	})
-
 	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
-	maxDiff := slices.MaxFunc(diffs, func(a, b FileDiff) int {
-		return cmp.Compare(a.ChangeRate, b.ChangeRate)
-	})
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
 
@@ -36,7 +32,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|
-`, resultLabel(pass), changeRateThreshold, formatMax(maxDiff.ChangeRate, maxDiff.Name)); err != nil {
+`, resultLabel(pass), changeRateThreshold, formatMax(diffs[0].ChangeRate, diffs[0].Name)); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -1,0 +1,123 @@
+package detection
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"maps"
+	"slices"
+
+	"github.com/pkg/errors"
+)
+
+// generateReport writes a Markdown report for detection diff to w.
+// It returns whether all files passed and any write error.
+func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold float64) (bool, error) {
+	diffs := slices.Collect(maps.Values(diffm))
+	slices.SortFunc(diffs, func(a, b FileDiff) int {
+		return cmp.Or(
+			cmp.Compare(b.ChangeRate, a.ChangeRate),
+			cmp.Compare(a.Name, b.Name),
+		)
+	})
+
+	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
+
+	overallResult := func() string {
+		if !pass {
+			return "FAIL"
+		}
+		return "PASS"
+	}()
+
+	maxName := ""
+	maxRate := 0.0
+	for _, d := range diffs {
+		if d.ChangeRate > maxRate {
+			maxRate = d.ChangeRate
+			maxName = d.Name
+		}
+	}
+	maxCell := fmt.Sprintf("%.1f%%", maxRate)
+	if maxName != "" {
+		maxCell = fmt.Sprintf("%.1f%% (%s)", maxRate, maxName)
+	}
+
+	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
+
+**Result**: %s
+**Change Rate Threshold**: %.1f%%
+**Change Rate Max**:       %s
+
+## Summary
+
+| Name | Baseline | Target | Added | Removed | Change Rate | Result |
+|------|----------|--------|-------|---------|-------------|--------|
+`, overallResult, changeRateThreshold, maxCell); err != nil {
+		return false, errors.Wrap(err, "write header")
+	}
+
+	for _, d := range diffs {
+		result := func() string {
+			if !d.Pass {
+				return "**FAIL**"
+			}
+			return "PASS"
+		}()
+		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s |\n",
+			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate, result); err != nil {
+			return false, errors.Wrap(err, "write summary row")
+		}
+	}
+
+	if _, err := fmt.Fprintln(w); err != nil {
+		return false, errors.Wrap(err, "write separator")
+	}
+
+	// Details for FAIL files
+	var failDiffs []FileDiff
+	for _, d := range diffs {
+		if !d.Pass {
+			failDiffs = append(failDiffs, d)
+		}
+	}
+
+	if len(failDiffs) > 0 {
+		if _, err := fmt.Fprintf(w, "## Details (FAIL files)\n\n"); err != nil {
+			return false, errors.Wrap(err, "write details header")
+		}
+		for _, d := range failDiffs {
+			if _, err := fmt.Fprintf(w, "### %s\n\n", d.Name); err != nil {
+				return false, errors.Wrapf(err, "write file header %s", d.Name)
+			}
+			if len(d.Added) > 0 {
+				if _, err := fmt.Fprintf(w, "#### Added IDs (%d)\n\n", len(d.Added)); err != nil {
+					return false, errors.Wrapf(err, "write added header %s", d.Name)
+				}
+				for _, id := range d.Added {
+					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
+						return false, errors.Wrapf(err, "write added ID %s", d.Name)
+					}
+				}
+				if _, err := fmt.Fprintln(w); err != nil {
+					return false, errors.Wrapf(err, "write added separator %s", d.Name)
+				}
+			}
+			if len(d.Removed) > 0 {
+				if _, err := fmt.Fprintf(w, "#### Removed IDs (%d)\n\n", len(d.Removed)); err != nil {
+					return false, errors.Wrapf(err, "write removed header %s", d.Name)
+				}
+				for _, id := range d.Removed {
+					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
+						return false, errors.Wrapf(err, "write removed ID %s", d.Name)
+					}
+				}
+				if _, err := fmt.Fprintln(w); err != nil {
+					return false, errors.Wrapf(err, "write removed separator %s", d.Name)
+				}
+			}
+		}
+	}
+
+	return pass, nil
+}

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -22,19 +22,9 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	})
 
 	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
-
-	maxName := ""
-	maxRate := 0.0
-	for _, d := range diffs {
-		if d.ChangeRate > maxRate {
-			maxRate = d.ChangeRate
-			maxName = d.Name
-		}
-	}
-	maxCell := fmt.Sprintf("%.1f%%", maxRate)
-	if maxName != "" {
-		maxCell = fmt.Sprintf("%.1f%% (%s)", maxRate, maxName)
-	}
+	maxDiff := slices.MaxFunc(diffs, func(a, b FileDiff) int {
+		return cmp.Compare(a.ChangeRate, b.ChangeRate)
+	})
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
 
@@ -46,7 +36,7 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|
-`, resultLabel(pass), changeRateThreshold, maxCell); err != nil {
+`, resultLabel(pass), changeRateThreshold, formatMax(maxDiff.ChangeRate, maxDiff.Name)); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 
@@ -82,27 +72,14 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 					return false, errors.Wrapf(err, "write added header %s", d.Name)
 				}
 				slices.Sort(d.Added)
-				for _, id := range d.Added {
-					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
-						return false, errors.Wrapf(err, "write added ID %s", d.Name)
-					}
-				}
-				if _, err := fmt.Fprintln(w); err != nil {
-					return false, errors.Wrapf(err, "write added separator %s", d.Name)
+				if err := writeIDList(w, "Added IDs", d.Added); err != nil {
+					return false, errors.Wrapf(err, "write added IDs %s", d.Name)
 				}
 			}
 			if len(d.Removed) > 0 {
-				if _, err := fmt.Fprintf(w, "#### Removed IDs (%d)\n\n", len(d.Removed)); err != nil {
-					return false, errors.Wrapf(err, "write removed header %s", d.Name)
-				}
 				slices.Sort(d.Removed)
-				for _, id := range d.Removed {
-					if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
-						return false, errors.Wrapf(err, "write removed ID %s", d.Name)
-					}
-				}
-				if _, err := fmt.Fprintln(w); err != nil {
-					return false, errors.Wrapf(err, "write removed separator %s", d.Name)
+				if err := writeIDList(w, "Removed IDs", d.Removed); err != nil {
+					return false, errors.Wrapf(err, "write removed IDs %s", d.Name)
 				}
 			}
 		}
@@ -111,9 +88,38 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	return pass, nil
 }
 
+// formatMax renders a "<rate>% (<name>)" cell for the report header, omitting
+// the name part when the rate is 0 (no non-zero change exists).
+func formatMax(rate float64, name string) string {
+	if rate == 0 {
+		return fmt.Sprintf("%.1f%%", rate)
+	}
+	return fmt.Sprintf("%.1f%% (%s)", rate, name)
+}
+
 func resultLabel(pass bool) string {
 	if pass {
 		return "PASS"
 	}
 	return "**FAIL**"
+}
+
+// writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.
+// It is a no-op when ids is empty.
+func writeIDList(w io.Writer, label string, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(w, "#### %s (%d)\n\n", label, len(ids)); err != nil {
+		return errors.Wrap(err, "write header")
+	}
+	for _, id := range ids {
+		if _, err := fmt.Fprintf(w, "- %s\n", id); err != nil {
+			return errors.Wrap(err, "write id")
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return errors.Wrap(err, "write separator")
+	}
+	return nil
 }

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -64,9 +64,6 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 				return false, errors.Wrapf(err, "write file header %s", d.Name)
 			}
 			if len(d.Added) > 0 {
-				if _, err := fmt.Fprintf(w, "#### Added IDs (%d)\n\n", len(d.Added)); err != nil {
-					return false, errors.Wrapf(err, "write added header %s", d.Name)
-				}
 				slices.Sort(d.Added)
 				if err := writeIDList(w, "Added IDs", d.Added); err != nil {
 					return false, errors.Wrapf(err, "write added IDs %s", d.Name)

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -23,13 +23,6 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
 
-	overallResult := func() string {
-		if !pass {
-			return "FAIL"
-		}
-		return "PASS"
-	}()
-
 	maxName := ""
 	maxRate := 0.0
 	for _, d := range diffs {
@@ -53,19 +46,13 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 | Name | Baseline | Target | Added | Removed | Change Rate | Result |
 |------|----------|--------|-------|---------|-------------|--------|
-`, overallResult, changeRateThreshold, maxCell); err != nil {
+`, resultLabel(pass), changeRateThreshold, maxCell); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 
 	for _, d := range diffs {
-		result := func() string {
-			if !d.Pass {
-				return "**FAIL**"
-			}
-			return "PASS"
-		}()
 		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s |\n",
-			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate, result); err != nil {
+			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate, resultLabel(d.Pass)); err != nil {
 			return false, errors.Wrap(err, "write summary row")
 		}
 	}
@@ -120,4 +107,11 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	}
 
 	return pass, nil
+}
+
+func resultLabel(pass bool) string {
+	if pass {
+		return "PASS"
+	}
+	return "**FAIL**"
 }


### PR DESCRIPTION
## Summary

Add `vuls diff` subcommand tree to detect regressions in DB publishing.

Two guard modes that gate nightly DB builds in CI:

- **`vuls diff db`** — Direct BoltDB comparison at the Criterion level using sorted-cursor merge-join. No scan results needed. Detects added/removed/changed root IDs and measures criterion-level change rate.
- **`vuls diff detection`** — Runs vuls0 detection against baseline and target (binary, DB) pairs using real scan results, then compares detected CVE IDs per file.

Both modes output a Markdown report (with overall result, threshold, and the ecosystem/file with the highest change rate) and exit non-zero when the change rate exceeds `--change-rate-threshold`.

### Design notes

- `diff db` intentionally bypasses the Storage abstraction and operates on `*bolt.DB` directly, because the merge-join algorithm requires sorted cursor iteration across two databases simultaneously.
- Criterion comparison uses `annotatedCriterion` that pairs each leaf Criterion with its operator path from the root Criteria, so operator-only changes are detected.
- Change rate formula: `(baseline - matched + target - matched) / baseline * 100`. Can exceed 100% when additions outnumber baseline entries — capping would hide the magnitude of large additions.
- `diff detection` compares only CVE ID sets (not per-CVE metadata). Content-only changes are invisible. This is sufficient for regression detection but not for data source migrations where IDs stay the same but metadata differs.

### Report output

```
# Diff Report: DB

**Result**: PASS
**Change Rate Threshold**: 10.0%
**Change Rate Max**:       0.3% (redhat:9)

## Summary

| Ecosystem | Baseline Keys | ... | Change Rate | Result |
|-----------|---------------|-----|-------------|--------|
| redhat:9  | 800           | ... | 0.3%        | PASS   |
| alma:8    | 50            | ... | 0.1%        | PASS   |
```

## Package layout

| Package | Role |
|---------|------|
| `pkg/cmd/diff/` | Cobra command wiring (`db`, `detection`) |
| `pkg/db/diff/db/` | BoltDB diff logic, report, fixtures, tests |
| `pkg/db/diff/detection/` | Detection diff logic, vuls0 orchestration, report, tests |
