### PR TITLE
fix(detect/microsoft): require release match for bare KB products

### DIFF
--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -68,7 +68,7 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 				if !filterMicrosoftKBProduct(p, sr.Release) {
 					continue
 				}
-				if vcm[p] == nil {
+				if _, ok := vcm[p]; !ok {
 					vcm[p] = nil
 				}
 			}
@@ -224,11 +224,17 @@ var microsoftPackageNameRules = []normalizeRule{
 }
 
 func filterMicrosoftKBProduct(product, release string) bool {
-	suffix := extractOSSuffix(product)
-	if suffix == "" {
+	if release == "" {
 		return true
 	}
-	return release == "" || suffix == release
+	suffix := extractOSSuffix(product)
+	if suffix == "" {
+		// Bare OS name (e.g. "Windows 10 Version 21H2 for x64-based Systems",
+		// "Windows Server 2012 R2"). Must match release exactly to avoid
+		// cross-product contamination from multi-product KBs.
+		return product == release
+	}
+	return suffix == release
 }
 
 func extractOSSuffix(product string) string {

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -568,12 +568,28 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "no suffix passes",
+			name: "no suffix, non-matching product filtered",
 			args: args{
 				product: "Microsoft Edge (Chromium-based)",
 				release: "Windows 10 Version 1607 for x64-based Systems",
 			},
+			want: false,
+		},
+		{
+			name: "bare OS name matching release passes",
+			args: args{
+				product: "Windows 10 Version 21H2 for x64-based Systems",
+				release: "Windows 10 Version 21H2 for x64-based Systems",
+			},
 			want: true,
+		},
+		{
+			name: "bare OS name cross-product filtered",
+			args: args{
+				product: "Windows Server 2012 R2",
+				release: "Windows 10 Version 21H2 for x64-based Systems",
+			},
+			want: false,
 		},
 		{
 			name: "matching release passes",
@@ -611,6 +627,14 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 			name: "empty release passes any suffix",
 			args: args{
 				product: "Microsoft Edge (EdgeHTML-based) on Windows 10 Version 1511 for x64-based Systems",
+				release: "",
+			},
+			want: true,
+		},
+		{
+			name: "empty release passes bare product",
+			args: args{
+				product: "Windows Server 2012 R2",
 				release: "",
 			},
 			want: true,


### PR DESCRIPTION
 filterMicrosoftKBProduct previously allowed all products without an
 " on " suffix to pass through regardless of release. This caused
 cross-product contamination when multi-product KBs (e.g. KB5012170
 covering both Windows 10 and Windows Server) added unrelated product
 names to the vcm index, triggering false positive detections for
 other OS editions (e.g. Server CVEs detected on a Windows 10 scan).

 Require bare OS product names to match the scan release exactly.
 Products with " on " suffix continue to compare the suffix as before.

 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>