### PR TITLE
fix(detect/microsoft): prefer unapplied when KB exists in both lists

### DIFF
--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -112,9 +112,17 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 }
 
 func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string) ([]string, error) {
+	// Prefer unapplied when a KB appears in both lists because:
+	// 1. QueryHistory may record a past successful install (Operation=1, ResultCode=2) even after
+	//    the update was rolled back or never fully applied, causing a false "applied" entry.
+	// 2. RebootRequired=1 KBs are intentionally placed in unapplied by the scanner, but other
+	//    sources (e.g. Get-HotFix) may also add them to applied, masking the pending reboot state.
 	appliedSet := make(map[string]struct{}, len(applied))
 	for _, kb := range applied {
 		appliedSet[kb] = struct{}{}
+	}
+	for _, kb := range unapplied {
+		delete(appliedSet, kb)
 	}
 
 	// Collect all reachable KBs by traversing SupersededBy chains forward

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -451,6 +451,20 @@ func Test_computeUnappliedKBs(t *testing.T) {
 			},
 			want: nil,
 		},
+		{
+			name:    "KB in both applied and unapplied prefers unapplied",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:   []string{"5000802", "5001330"},
+				unapplied: []string{"5000802"},
+			},
+			want: []string{"5000802", "5003173"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
   When a KB appears in both the applied and unapplied lists, treat it as
   unapplied. This avoids false negatives caused by:

   1. QueryHistory recording a past successful install even after the update was rolled back or never fully applied.
   2. RebootRequired=1 KBs being added to applied by other sources (e.g. Get-HotFix), masking the pending reboot state.

   Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>