### PR TITLE
fix(detect/microsoft): exclude KBs covered by applied superseding KB

### DIFF
--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -121,14 +121,19 @@ func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string
 	for _, kb := range applied {
 		appliedSet[kb] = struct{}{}
 	}
+	removedFromApplied := make(map[string]struct{})
 	for _, kb := range unapplied {
+		if _, ok := appliedSet[kb]; ok {
+			removedFromApplied[kb] = struct{}{}
+		}
 		delete(appliedSet, kb)
 	}
 
 	// Collect all reachable KBs by traversing SupersededBy chains forward
-	// from both Applied and Unapplied. Any discovered KB not in Applied is unapplied.
+	// from both Applied and Unapplied, and build a reverse edge map
+	// (superseding KB → list of superseded KBs) for the coverage BFS.
 	visited := make(map[string]struct{})
-	unappliedSet := make(map[string]struct{})
+	revEdges := make(map[string][]string)
 
 	var walk func(kbid string) error
 	walk = func(kbid string) error {
@@ -136,10 +141,6 @@ func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string
 			return nil
 		}
 		visited[kbid] = struct{}{}
-
-		if _, ok := appliedSet[kbid]; !ok {
-			unappliedSet[kbid] = struct{}{}
-		}
 
 		m, err := s.GetMicrosoftKB(kbid)
 		if err != nil {
@@ -154,8 +155,9 @@ func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string
 				if sup.KBID == "" {
 					continue
 				}
+				revEdges[sup.KBID] = append(revEdges[sup.KBID], kbid)
 				if err := walk(sup.KBID); err != nil {
-					return err
+					return errors.Wrapf(err, "walk supersession from KB %s to %s", kbid, sup.KBID)
 				}
 			}
 			for _, u := range kb.Updates {
@@ -163,8 +165,9 @@ func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string
 					if sup.KBID == "" {
 						continue
 					}
+					revEdges[sup.KBID] = append(revEdges[sup.KBID], kbid)
 					if err := walk(sup.KBID); err != nil {
-						return err
+						return errors.Wrapf(err, "walk supersession from KB %s to %s (via update)", kbid, sup.KBID)
 					}
 				}
 			}
@@ -184,7 +187,41 @@ func computeUnappliedKBs(s session.Storage, applied []string, unapplied []string
 		}
 	}
 
-	return slices.Collect(maps.Keys(unappliedSet)), nil
+	// Find all KBs covered by an applied superseding KB. BFS backwards from
+	// appliedSet through reverse edges. Handles cycles via the covered set.
+	covered := make(map[string]struct{}, len(appliedSet))
+	queue := make([]string, 0, len(appliedSet))
+	for kbid := range appliedSet {
+		if _, ok := visited[kbid]; ok {
+			covered[kbid] = struct{}{}
+			queue = append(queue, kbid)
+		}
+	}
+	for head := 0; head < len(queue); head++ {
+		cur := queue[head]
+		for _, pred := range revEdges[cur] {
+			if _, ok := covered[pred]; !ok {
+				covered[pred] = struct{}{}
+				queue = append(queue, pred)
+			}
+		}
+	}
+
+	// A KB is unapplied if it was discovered (in visited) and either:
+	//   - not covered by any applied superseding KB, or
+	//   - removed from appliedSet by unapplied-preference (always treated as
+	//     unapplied regardless of coverage, to honour the scanner's signal).
+	var unappliedKBs []string
+	for kbid := range visited {
+		if _, ok := covered[kbid]; ok {
+			if _, ok := removedFromApplied[kbid]; !ok {
+				continue
+			}
+		}
+		unappliedKBs = append(unappliedKBs, kbid)
+	}
+
+	return unappliedKBs, nil
 }
 
 func normalizeMicrosoftPackageName(name, release string) []string {

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -59,7 +59,7 @@ func TestDetect(t *testing.T) {
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
 		},
 		{
-			name:    "detect CVE-2021-1640 by unapplied KB",
+			name:    "detect CVE-2021-1640 and CVE-2021-26413 by unapplied KB with supersession",
 			fixture: "testdata/fixtures/microsoft-supersession",
 			config: session.Config{
 				Type:    "boltdb",
@@ -72,7 +72,6 @@ func TestDetect(t *testing.T) {
 					Family:  ecosystemTypes.EcosystemTypeMicrosoft,
 					Release: "Windows 10 Version 2004 for x64-based Systems",
 					MicrosoftKB: scanTypes.MicrosoftKB{
-						Applied:   []string{"5001330"},
 						Unapplied: []string{"5000802"},
 					},
 				},
@@ -104,6 +103,31 @@ func TestDetect(t *testing.T) {
 						},
 					},
 				},
+				"CVE-2021-26413": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterions: []criterionTypes.FilteredCriterion{
+										{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeKB,
+												KB: &kbcTypes.Criterion{
+													Product: "Windows 10 Version 2004 for x64-based Systems",
+													KBID:    "5001330",
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{KB: true},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -121,6 +145,28 @@ func TestDetect(t *testing.T) {
 					Release: "Windows 10 Version 2004 for x64-based Systems",
 					MicrosoftKB: scanTypes.MicrosoftKB{
 						Applied: []string{"5000802", "5001330"},
+					},
+				},
+				concurrency: 1,
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+		},
+		{
+			name:    "fix KB covered by applied superseding KB, no detection",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+				sr: scanTypes.ScanResult{
+					Family:  ecosystemTypes.EcosystemTypeMicrosoft,
+					Release: "Windows 10 Version 2004 for x64-based Systems",
+					MicrosoftKB: scanTypes.MicrosoftKB{
+						Applied:   []string{"5001330"},
+						Unapplied: []string{"5000802"},
 					},
 				},
 				concurrency: 1,
@@ -422,7 +468,7 @@ func Test_computeUnappliedKBs(t *testing.T) {
 			args: args{
 				applied: []string{"5000802"},
 			},
-			want: []string{"5001330", "5003173"},
+			want: []string{"5001330", "5003173", "5003637"},
 		},
 		{
 			name:    "unapplied with chain",
@@ -436,10 +482,10 @@ func Test_computeUnappliedKBs(t *testing.T) {
 				applied:   []string{},
 				unapplied: []string{"5000802"},
 			},
-			want: []string{"5000802", "5001330", "5003173"},
+			want: []string{"5000802", "5001330", "5003173", "5003637"},
 		},
 		{
-			name:    "all applied returns empty",
+			name:    "latest superseding KB not applied remains unapplied",
 			fixture: "testdata/fixtures/microsoft-supersession",
 			config: session.Config{
 				Type:    "boltdb",
@@ -449,7 +495,20 @@ func Test_computeUnappliedKBs(t *testing.T) {
 			args: args{
 				applied: []string{"5000802", "5001330", "5003173"},
 			},
-			want: nil,
+			want: []string{"5003637"},
+		},
+		{
+			name:    "intermediate KB covered by applied superseding KB",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied: []string{"5000802", "5003173"},
+			},
+			want: []string{"5003637"},
 		},
 		{
 			name:    "KB in both applied and unapplied prefers unapplied",
@@ -463,7 +522,7 @@ func Test_computeUnappliedKBs(t *testing.T) {
 				applied:   []string{"5000802", "5001330"},
 				unapplied: []string{"5000802"},
 			},
-			want: []string{"5000802", "5003173"},
+			want: []string{"5000802", "5003173", "5003637"},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-cvrf/microsoftkb/5003xxx/5003173.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-cvrf/microsoftkb/5003xxx/5003173.json
@@ -1,0 +1,19 @@
+{
+  "kb_id": "5003173",
+  "url": "https://support.microsoft.com/help/5003173",
+  "products": [
+    "Windows 10 Version 2004 for x64-based Systems",
+    "Windows 10 Version 20H2 for x64-based Systems"
+  ],
+  "superseded_by": [
+    {
+      "kb_id": "5003637"
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-cvrf",
+    "raws": [
+      "vuls-data-raw-microsoft-cvrf/2021-May/2021/CVE-2021-31184.json"
+    ]
+  }
+}


### PR DESCRIPTION
When traversing supersession chains, intermediate KBs discovered between
two applied KBs were incorrectly treated as unapplied. Since cumulative
updates include all prior fixes, a KB whose superseding KB is applied is
already covered and should not appear in the unapplied set.

Build a forward edge graph during chain traversal, then compute coverage
via reverse-edge BFS from the applied set — marking all predecessors as
covered. This avoids cycle-related correctness issues that arise with
recursive DFS memoization. Also wrap walk() errors with context.