### PR TITLE
fix(db/session/types): condition segments check on Ecosystems

### DIFF
--- a/pkg/db/session/types/types.go
+++ b/pkg/db/session/types/types.go
@@ -151,7 +151,7 @@ func (f Filter) ApplyToAdvisories(asmm map[sourceTypes.SourceID]map[dataTypes.Ro
 
 			for _, a := range as {
 				a.Segments = f.applyToSegments(a.Segments)
-				if len(a.Segments) == 0 {
+				if len(f.Ecosystems) > 0 && len(a.Segments) == 0 {
 					continue
 				}
 
@@ -184,7 +184,7 @@ func (f Filter) ApplyToVulnerabilities(vsmm map[sourceTypes.SourceID]map[dataTyp
 
 			for _, v := range vs {
 				v.Segments = f.applyToSegments(v.Segments)
-				if len(v.Segments) == 0 {
+				if len(f.Ecosystems) > 0 && len(v.Segments) == 0 {
 					continue
 				}
 

--- a/pkg/db/session/types/types_test.go
+++ b/pkg/db/session/types/types_test.go
@@ -1371,6 +1371,112 @@ func TestFilter_ApplyToAdvisories(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "filter by datasource only with empty segments",
+			fields: fields{
+				DataSources: []sourceTypes.SourceID{"source-1"},
+			},
+			args: args{
+				asmm: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+					"source-1": {
+						"root-1": {
+							{
+								Content: advisoryContentTypes.Content{
+									ID: "adv-1",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "ubuntu:24.04"},
+								},
+							},
+						},
+						"root-2": {
+							{
+								Content: advisoryContentTypes.Content{
+									ID: "adv-2",
+								},
+							},
+						},
+					},
+					"source-2": {
+						"root-3": {
+							{
+								Content: advisoryContentTypes.Content{
+									ID: "adv-3",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "oracle:9"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+				"source-1": {
+					"root-1": {
+						{
+							Content: advisoryContentTypes.Content{
+								ID: "adv-1",
+							},
+							Segments: []segmentTypes.Segment{
+								{Ecosystem: "ubuntu:24.04"},
+							},
+						},
+					},
+					"root-2": {
+						{
+							Content: advisoryContentTypes.Content{
+								ID: "adv-2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter by datasource and ecosystem with empty segments",
+			fields: fields{
+				DataSources: []sourceTypes.SourceID{"source-1"},
+				Ecosystems:  []ecosystemTypes.Ecosystem{"ubuntu:24.04"},
+			},
+			args: args{
+				asmm: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+					"source-1": {
+						"root-1": {
+							{
+								Content: advisoryContentTypes.Content{
+									ID: "adv-1",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "ubuntu:24.04"},
+								},
+							},
+						},
+						"root-2": {
+							{
+								Content: advisoryContentTypes.Content{
+									ID: "adv-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[sourceTypes.SourceID]map[dataTypes.RootID][]advisoryTypes.Advisory{
+				"source-1": {
+					"root-1": {
+						{
+							Content: advisoryContentTypes.Content{
+								ID: "adv-1",
+							},
+							Segments: []segmentTypes.Segment{
+								{Ecosystem: "ubuntu:24.04"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2298,6 +2404,112 @@ func TestFilter_ApplyToVulnerabilities(t *testing.T) {
 							},
 							Segments: []segmentTypes.Segment{
 								{Ecosystem: "oracle:9"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter by datasource only with empty segments",
+			fields: fields{
+				DataSources: []sourceTypes.SourceID{"source-1"},
+			},
+			args: args{
+				vsmm: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+					"source-1": {
+						"root-1": {
+							{
+								Content: vulnerabilityContentTypes.Content{
+									ID: "vuln-1",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "ubuntu:24.04"},
+								},
+							},
+						},
+						"root-2": {
+							{
+								Content: vulnerabilityContentTypes.Content{
+									ID: "vuln-2",
+								},
+							},
+						},
+					},
+					"source-2": {
+						"root-3": {
+							{
+								Content: vulnerabilityContentTypes.Content{
+									ID: "vuln-3",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "oracle:9"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+				"source-1": {
+					"root-1": {
+						{
+							Content: vulnerabilityContentTypes.Content{
+								ID: "vuln-1",
+							},
+							Segments: []segmentTypes.Segment{
+								{Ecosystem: "ubuntu:24.04"},
+							},
+						},
+					},
+					"root-2": {
+						{
+							Content: vulnerabilityContentTypes.Content{
+								ID: "vuln-2",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "filter by datasource and ecosystem with empty segments",
+			fields: fields{
+				DataSources: []sourceTypes.SourceID{"source-1"},
+				Ecosystems:  []ecosystemTypes.Ecosystem{"ubuntu:24.04"},
+			},
+			args: args{
+				vsmm: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+					"source-1": {
+						"root-1": {
+							{
+								Content: vulnerabilityContentTypes.Content{
+									ID: "vuln-1",
+								},
+								Segments: []segmentTypes.Segment{
+									{Ecosystem: "ubuntu:24.04"},
+								},
+							},
+						},
+						"root-2": {
+							{
+								Content: vulnerabilityContentTypes.Content{
+									ID: "vuln-2",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: map[sourceTypes.SourceID]map[dataTypes.RootID][]vulnerabilityTypes.Vulnerability{
+				"source-1": {
+					"root-1": {
+						{
+							Content: vulnerabilityContentTypes.Content{
+								ID: "vuln-1",
+							},
+							Segments: []segmentTypes.Segment{
+								{Ecosystem: "ubuntu:24.04"},
 							},
 						},
 					},


### PR DESCRIPTION
 ApplyToVulnerabilities and ApplyToAdvisories incorrectly excluded
 entries with empty Segments (e.g., KEV, MITRE) when only DataSources
 filter was specified. The len(v.Segments) == 0 check now only applies
 when Ecosystems filter is present.