### PR TITLE
fix(db/ecosystems): exclude "microsoft" from GetEcosystems

### DIFF
--- a/pkg/db/session/internal/boltdb/boltdb.go
+++ b/pkg/db/session/internal/boltdb/boltdb.go
@@ -24,6 +24,7 @@ import (
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session/internal/util"
 	dbTypes "github.com/MaineK00n/vuls2/pkg/db/session/types"
+	boltdbTypes "github.com/MaineK00n/vuls2/pkg/db/session/types/boltdb"
 	"github.com/MaineK00n/vuls2/pkg/version"
 )
 
@@ -667,9 +668,7 @@ func (c *Connection) GetEcosystems() ([]ecosystemTypes.Ecosystem, error) {
 	var es []ecosystemTypes.Ecosystem
 	if err := c.conn.View(func(tx *bolt.Tx) error {
 		return tx.ForEach(func(name []byte, _ *bolt.Bucket) error {
-			switch n := string(name); n {
-			case "metadata", "vulnerability", "datasource":
-			default:
+			if !slices.Contains(boltdbTypes.ReservedRootBucket(), string(name)) {
 				es = append(es, ecosystemTypes.Ecosystem(name))
 			}
 			return nil

--- a/pkg/db/session/internal/boltdb/boltdb_test.go
+++ b/pkg/db/session/internal/boltdb/boltdb_test.go
@@ -676,6 +676,14 @@ func TestConnection_GetEcosystems(t *testing.T) {
 			},
 			want: []ecosystemTypes.Ecosystem{"alma:8"},
 		},
+		{
+			name:    "microsoft bucket is reserved",
+			fixture: "testdata/fixtures/microsoft-small",
+			fields: fields{
+				Config: &boltdb.Config{Path: filepath.Join(t.TempDir(), "vuls.db")},
+			},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/db/session/types/boltdb/boltdb.go
+++ b/pkg/db/session/types/boltdb/boltdb.go
@@ -1,0 +1,8 @@
+package boltdb
+
+// ReservedRootBucket returns the set of top-level bucket names that are not
+// ecosystems. A new slice is returned on each call so that callers cannot
+// mutate shared state.
+func ReservedRootBucket() []string {
+	return []string{"datasource", "metadata", "microsoft", "vulnerability"}
+}


### PR DESCRIPTION
## Summary

- Fix an issue where `microsoft` was incorrectly included in the output of the `vuls db search ecosystem` subcommand. `GetEcosystems` now excludes reserved root buckets (including `microsoft`).
- Move the related code out of `internal` so that it can be referenced from the upcoming `vuls diff db` command.