### PR TITLE
feat(cmd): add kb-expand to trace Microsoft KB supersession 

### DIFF
--- a/pkg/cmd/db/search/search.go
+++ b/pkg/cmd/db/search/search.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"path/filepath"
+	"slices"
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/pkg/errors"
@@ -361,10 +362,22 @@ func newKBExpandCmd() *cobra.Command {
 		$ vuls db search kb-expand --applied 5034441 --datasource microsoft-cvrf --explain
 		`),
 		Args: cobra.NoArgs,
-		RunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			// Drop empty entries up front. StringSlice splits on commas
+			// and keeps empty tokens, so `--applied ,5000802` and
+			// `--applied ""` both produce `""` elements that ExpandKBs
+			// would treat as inert. Normalising here makes the
+			// required-input check operate on effective IDs and avoids
+			// "no input"-style output when the user accidentally passed
+			// only empty entries.
+			options.applied = slices.DeleteFunc(options.applied, func(s string) bool { return s == "" })
+			options.unapplied = slices.DeleteFunc(options.unapplied, func(s string) bool { return s == "" })
 			if len(options.applied) == 0 && len(options.unapplied) == 0 {
-				return errors.New("at least one of --applied or --unapplied is required")
+				return errors.New("at least one of --applied or --unapplied with a non-empty KB ID is required")
 			}
+			return nil
+		},
+		RunE: func(_ *cobra.Command, _ []string) error {
 			ds := make([]sourceTypes.SourceID, 0, len(options.datasources))
 			for _, d := range options.datasources {
 				ds = append(ds, sourceTypes.SourceID(d))

--- a/pkg/cmd/db/search/search.go
+++ b/pkg/cmd/db/search/search.go
@@ -336,13 +336,14 @@ func newKBVulnCmd() *cobra.Command {
 
 func newKBExpandCmd() *cobra.Command {
 	options := struct {
-		dbtype    utilflag.DBType
-		dbpath    string
-		applied   []string
-		unapplied []string
-		release   string
-		explain   bool
-		debug     bool
+		dbtype      utilflag.DBType
+		dbpath      string
+		applied     []string
+		unapplied   []string
+		releases    []string
+		datasources []string
+		explain     bool
+		debug       bool
 	}{
 		dbtype: utilflag.DBTypeBoltDB,
 		dbpath: filepath.Join(utilos.UserCacheDir(), "vuls.db"),
@@ -356,13 +357,26 @@ func newKBExpandCmd() *cobra.Command {
 		$ vuls db search kb-expand --applied 5034441,5034122 --unapplied 5036893
 		$ vuls db search kb-expand --applied 5034441 --explain
 		$ vuls db search kb-expand --applied 5034441 --release "Windows 10 Version 22H2 for x64-based Systems" --explain
+		$ vuls db search kb-expand --applied 5034441 --release "Windows 10 Version 22H2 for x64-based Systems" --release "Windows 11 Version 23H2 for x64-based Systems"
+		$ vuls db search kb-expand --applied 5034441 --datasource microsoft-cvrf --explain
 		`),
 		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if len(options.applied) == 0 && len(options.unapplied) == 0 {
 				return errors.New("at least one of --applied or --unapplied is required")
 			}
-			if err := db.SearchKBExpand(options.applied, options.unapplied, options.release, options.explain,
+			ds := make([]sourceTypes.SourceID, 0, len(options.datasources))
+			for _, d := range options.datasources {
+				ds = append(ds, sourceTypes.SourceID(d))
+			}
+			req := db.KBExpandRequest{
+				Applied:     options.applied,
+				Unapplied:   options.unapplied,
+				Releases:    options.releases,
+				DataSources: ds,
+				Explain:     options.explain,
+			}
+			if err := db.SearchKBExpand(req,
 				db.WithDBType(options.dbtype.String()),
 				db.WithDBPath(options.dbpath),
 				db.WithDebug(options.debug),
@@ -378,7 +392,8 @@ func newKBExpandCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&options.dbpath, "dbpath", "", options.dbpath, "vuls db path")
 	cmd.Flags().StringSliceVarP(&options.applied, "applied", "", options.applied, "applied KB IDs (comma-separated or repeat the flag)")
 	cmd.Flags().StringSliceVarP(&options.unapplied, "unapplied", "", options.unapplied, "unapplied KB IDs (comma-separated or repeat the flag)")
-	cmd.Flags().StringVarP(&options.release, "release", "", options.release, "host release (e.g., \"Windows 10 Version 22H2 for x64-based Systems\"); when set, also reports KBs dropped by the release filter")
+	cmd.Flags().StringSliceVarP(&options.releases, "release", "", options.releases, "host release(s) (e.g., \"Windows 10 Version 22H2 for x64-based Systems\"); KBs relevant to any of the given releases are kept (comma-separated or repeat the flag)")
+	cmd.Flags().StringSliceVarP(&options.datasources, "datasource", "", options.datasources, "restrict supersession walking and product evaluation to the given Microsoft data sources (e.g., microsoft-cvrf, microsoft-msuc, microsoft-bulletin)")
 	cmd.Flags().BoolVarP(&options.explain, "explain", "", options.explain, "render the supersession chains as a tree with data-source attribution instead of JSON")
 	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
 

--- a/pkg/cmd/db/search/search.go
+++ b/pkg/cmd/db/search/search.go
@@ -31,6 +31,7 @@ func NewCmd() *cobra.Command {
 		newPackageCmd(),
 		newKBInfoCmd(),
 		newKBVulnCmd(),
+		newKBExpandCmd(),
 		newMetadataCmd(),
 		newDataSourcesCmd(),
 		newEcosystemsCmd(),
@@ -328,6 +329,57 @@ func newKBVulnCmd() *cobra.Command {
 	cmd.Flags().StringSliceVarP(&options.filterOpts.datasources, "datasource", "", options.filterOpts.datasources, "filter by datasource (e.g., redhat-vex, ubuntu-cve-tracker)")
 	cmd.Flags().StringSliceVarP(&options.filterOpts.rootIDs, "root-id", "", options.filterOpts.rootIDs, "filter by root ID (e.g., CVE-2024-4367)")
 
+	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
+
+	return cmd
+}
+
+func newKBExpandCmd() *cobra.Command {
+	options := struct {
+		dbtype    utilflag.DBType
+		dbpath    string
+		applied   []string
+		unapplied []string
+		release   string
+		explain   bool
+		debug     bool
+	}{
+		dbtype: utilflag.DBTypeBoltDB,
+		dbpath: filepath.Join(utilos.UserCacheDir(), "vuls.db"),
+		debug:  false,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "kb-expand",
+		Short: "expand input Microsoft KBs into covered/unapplied via supersession chains",
+		Example: heredoc.Doc(`
+		$ vuls db search kb-expand --applied 5034441,5034122 --unapplied 5036893
+		$ vuls db search kb-expand --applied 5034441 --explain
+		$ vuls db search kb-expand --applied 5034441 --release "Windows 10 Version 22H2 for x64-based Systems" --explain
+		`),
+		Args: cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if len(options.applied) == 0 && len(options.unapplied) == 0 {
+				return errors.New("at least one of --applied or --unapplied is required")
+			}
+			if err := db.SearchKBExpand(options.applied, options.unapplied, options.release, options.explain,
+				db.WithDBType(options.dbtype.String()),
+				db.WithDBPath(options.dbpath),
+				db.WithDebug(options.debug),
+			); err != nil {
+				return errors.Wrap(err, "db search")
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().VarP(&options.dbtype, "dbtype", "", "vuls db type (default: boltdb, accepts: [boltdb, redis, sqlite3, mysql, postgres])")
+	_ = cmd.RegisterFlagCompletionFunc("dbtype", utilflag.DBTypeCompletion)
+	cmd.Flags().StringVarP(&options.dbpath, "dbpath", "", options.dbpath, "vuls db path")
+	cmd.Flags().StringSliceVarP(&options.applied, "applied", "", options.applied, "applied KB IDs (comma-separated or repeat the flag)")
+	cmd.Flags().StringSliceVarP(&options.unapplied, "unapplied", "", options.unapplied, "unapplied KB IDs (comma-separated or repeat the flag)")
+	cmd.Flags().StringVarP(&options.release, "release", "", options.release, "host release (e.g., \"Windows 10 Version 22H2 for x64-based Systems\"); when set, also reports KBs dropped by the release filter")
+	cmd.Flags().BoolVarP(&options.explain, "explain", "", options.explain, "render the supersession chains as a tree with data-source attribution instead of JSON")
 	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
 
 	return cmd

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -1,6 +1,7 @@
 package search
 
 import (
+	"cmp"
 	"encoding/json/v2"
 	"fmt"
 	"io"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
@@ -639,26 +641,33 @@ func SearchKBVuln(queries []string, datasources []sourceTypes.SourceID, opts ...
 	return nil
 }
 
-// KBExpandResult is the JSON-serialisable form of a kb-expand run.
+// KBExpandResult is the JSON-serialisable summary of a kb-expand run.
+// It carries the classification (Covered / Unapplied / Conflicts) plus
+// the post-filter views, but intentionally omits the per-edge data-source
+// attribution and per-KB products that ExpandKBs collects; those are
+// rendered only by --explain, which gives chain-walking diagnostics a
+// human-friendly tree without expanding the JSON surface.
+//
+// Fields are ordered by lifecycle: inputs, then filter inputs, then the
+// covered/unapplied results paired with their post-filter views. The
+// covered_after_filter / *_dropped_by_filter fields are populated only
+// when Releases (and optionally DataSources) was supplied; the Releases
+// and DataSources fields carry the filter context.
 type KBExpandResult struct {
-	Inputs                      KBExpandInputs         `json:"inputs"`
-	DataSources                 []sourceTypes.SourceID `json:"datasources,omitempty"`
-	Covered                     []string               `json:"covered"`
-	Unapplied                   []string               `json:"unapplied"`
-	Conflicts                   []string               `json:"conflicts,omitempty"`
-	Releases                    []string               `json:"releases,omitempty"`
-	CoveredAfterReleaseFilter   []string               `json:"covered_after_release_filter,omitempty"`
-	UnappliedAfterReleaseFilter []string               `json:"unapplied_after_release_filter,omitempty"`
-	DroppedByRelease            *KBExpandDrop          `json:"dropped_by_release,omitempty"`
+	Inputs                   KBExpandInputs         `json:"inputs"`
+	Conflicts                []string               `json:"conflicts,omitempty"`
+	DataSources              []sourceTypes.SourceID `json:"datasources,omitempty"`
+	Releases                 []string               `json:"releases,omitempty"`
+	Covered                  []string               `json:"covered"`
+	CoveredAfterFilter       []string               `json:"covered_after_filter,omitempty"`
+	CoveredDroppedByFilter   []string               `json:"covered_dropped_by_filter,omitempty"`
+	Unapplied                []string               `json:"unapplied"`
+	UnappliedAfterFilter     []string               `json:"unapplied_after_filter,omitempty"`
+	UnappliedDroppedByFilter []string               `json:"unapplied_dropped_by_filter,omitempty"`
 }
 
 type KBExpandInputs struct {
 	Applied   []string `json:"applied,omitempty"`
-	Unapplied []string `json:"unapplied,omitempty"`
-}
-
-type KBExpandDrop struct {
-	Covered   []string `json:"covered,omitempty"`
 	Unapplied []string `json:"unapplied,omitempty"`
 }
 
@@ -691,10 +700,11 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 	}
 
 	s, err := (&session.Config{
-		Type:    options.dbtype,
-		Path:    options.dbpath,
-		Debug:   options.debug,
-		Options: options.storageopts,
+		Type:      options.dbtype,
+		Path:      options.dbpath,
+		Debug:     options.debug,
+		Options:   options.storageopts,
+		WithCache: true,
 	}).New()
 	if err != nil {
 		return errors.Wrap(err, "new db connection")
@@ -704,6 +714,8 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 		return errors.Wrap(err, "open db connection")
 	}
 	defer s.Storage().Close()
+
+	defer s.Cache().Close()
 
 	slog.Info("Get Metadata")
 	meta, err := s.Storage().GetMetadata()
@@ -719,11 +731,7 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 	}
 
 	slog.Info("Expand Microsoft KB", "applied", req.Applied, "unapplied", req.Unapplied, "datasources", req.DataSources)
-	expandOpts := []microsoft.ExpandOption{}
-	if len(req.DataSources) > 0 {
-		expandOpts = append(expandOpts, microsoft.WithExpandDataSources(req.DataSources))
-	}
-	exp, err := microsoft.ExpandKBs(s.Storage(), req.Applied, req.Unapplied, expandOpts...)
+	exp, err := microsoft.ExpandKBs(s.Storage(), req.Applied, req.Unapplied, req.DataSources)
 	if err != nil {
 		return errors.Wrap(err, "expand microsoft kb")
 	}
@@ -733,14 +741,34 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 		coveredDropped, unappliedDropped []string
 	)
 	if len(req.Releases) > 0 {
-		coveredAfter, coveredDropped, err = microsoft.PartitionKBIDsByReleases(s.Storage(), exp.Covered, req.Releases, expandOpts...)
-		if err != nil {
-			return errors.Wrap(err, "partition covered KBs by release")
-		}
-		unappliedAfter, unappliedDropped, err = microsoft.PartitionKBIDsByReleases(s.Storage(), exp.Unapplied, req.Releases, expandOpts...)
-		if err != nil {
-			return errors.Wrap(err, "partition unapplied KBs by release")
-		}
+		coveredAfter, coveredDropped = microsoft.PartitionKBIDsByReleases(exp.Products, exp.Covered, req.Releases)
+		unappliedAfter, unappliedDropped = microsoft.PartitionKBIDsByReleases(exp.Products, exp.Unapplied, req.Releases)
+	}
+
+	// Sort once here so the JSON and tree outputs are deterministic.
+	// ExpandKBs returns slices in map-iteration order and
+	// PartitionKBIDsByReleases preserves input order, so sorting after
+	// Partition leaves the kept/dropped slices consistent with their
+	// already-sorted source. The per-node edge slices in exp.Edges are
+	// also sorted because multi-source edges (e.g. cvrf + msuc both
+	// reporting the same SupersededBy) would otherwise render in storage
+	// map-iteration order.
+	slices.Sort(exp.Covered)
+	slices.Sort(exp.Unapplied)
+	slices.Sort(exp.Conflicts)
+	slices.Sort(coveredAfter)
+	slices.Sort(unappliedAfter)
+	slices.Sort(coveredDropped)
+	slices.Sort(unappliedDropped)
+	for _, es := range exp.Edges {
+		slices.SortFunc(es, func(a, b microsoft.ExpandEdge) int {
+			return cmp.Or(
+				cmp.Compare(a.To, b.To),
+				cmp.Compare(string(a.Source), string(b.Source)),
+				cmp.Compare(int(a.Level), int(b.Level)),
+				cmp.Compare(a.UpdateID, b.UpdateID),
+			)
+		})
 	}
 
 	if req.Explain {
@@ -756,14 +784,10 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 	}
 	if len(req.Releases) > 0 {
 		out.Releases = req.Releases
-		out.CoveredAfterReleaseFilter = coveredAfter
-		out.UnappliedAfterReleaseFilter = unappliedAfter
-		if len(coveredDropped) > 0 || len(unappliedDropped) > 0 {
-			out.DroppedByRelease = &KBExpandDrop{
-				Covered:   coveredDropped,
-				Unapplied: unappliedDropped,
-			}
-		}
+		out.CoveredAfterFilter = coveredAfter
+		out.UnappliedAfterFilter = unappliedAfter
+		out.CoveredDroppedByFilter = coveredDropped
+		out.UnappliedDroppedByFilter = unappliedDropped
 	}
 	if err := json.MarshalWrite(os.Stdout, out); err != nil {
 		return errors.Wrap(err, "encode kb-expand result")
@@ -772,12 +796,34 @@ func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 }
 
 func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []sourceTypes.SourceID, releases []string, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped []string) error {
+	classify := makeKBExpandClassifier(exp)
+
+	if err := writeKBExpandInputs(w, exp.Inputs, datasources); err != nil {
+		return errors.Wrap(err, "write inputs section")
+	}
+	if err := writeKBExpandConflicts(w, exp.Conflicts); err != nil {
+		return errors.Wrap(err, "write conflicts section")
+	}
+	if err := writeKBExpandChains(w, exp, classify); err != nil {
+		return errors.Wrap(err, "write supersession chains section")
+	}
+	if err := writeKBExpandResult(w, exp); err != nil {
+		return errors.Wrap(err, "write result section")
+	}
+	if len(releases) > 0 {
+		if err := writeKBExpandFilter(w, releases, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped); err != nil {
+			return errors.Wrap(err, "write release filter section")
+		}
+	}
+	return nil
+}
+
+func makeKBExpandClassifier(exp *microsoft.ExpandResult) func(string) string {
 	appliedSet := toSet(exp.Inputs.Applied)
 	unappliedSet := toSet(exp.Inputs.Unapplied)
 	coveredSet := toSet(exp.Covered)
 	resultUnappliedSet := toSet(exp.Unapplied)
-
-	classify := func(kbid string) string {
+	return func(kbid string) string {
 		var tags []string
 		_, isAppliedInput := appliedSet[kbid]
 		_, isUnappliedInput := unappliedSet[kbid]
@@ -797,76 +843,64 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []s
 		if _, ok := resultUnappliedSet[kbid]; ok {
 			tags = append(tags, "unapplied")
 		}
-		return fmt.Sprintf("[%s]", joinComma(tags))
+		return fmt.Sprintf("[%s]", strings.Join(tags, ", "))
 	}
+}
 
-	if _, err := fmt.Fprintln(w, "Inputs:"); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  Applied:   %s\n", joinSpace(exp.Inputs.Applied)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  Unapplied: %s\n", joinSpace(exp.Inputs.Unapplied)); err != nil {
-		return err
+func writeKBExpandInputs(w io.Writer, in microsoft.ExpandInputs, datasources []sourceTypes.SourceID) error {
+	if _, err := fmt.Fprintf(w, "Inputs:\n  Applied:   %s\n  Unapplied: %s\n", joinKBList(in.Applied), joinKBList(in.Unapplied)); err != nil {
+		return errors.Wrap(err, "write inputs header")
 	}
 	if len(datasources) > 0 {
 		dsStrs := make([]string, len(datasources))
 		for i, d := range datasources {
 			dsStrs[i] = string(d)
 		}
-		if _, err := fmt.Fprintf(w, "  Data sources: %s\n", joinSpace(dsStrs)); err != nil {
-			return err
+		if _, err := fmt.Fprintf(w, "  Data sources: %s\n", joinKBList(dsStrs)); err != nil {
+			return errors.Wrap(err, "write data sources")
 		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
-		return err
+		return errors.Wrap(err, "write inputs trailing newline")
 	}
+	return nil
+}
 
+func writeKBExpandConflicts(w io.Writer, conflicts []string) error {
 	if _, err := fmt.Fprintln(w, "Conflicts (in both Applied & Unapplied → treated as Unapplied):"); err != nil {
-		return err
+		return errors.Wrap(err, "write conflicts header")
 	}
-	if len(exp.Conflicts) == 0 {
+	if len(conflicts) == 0 {
 		if _, err := fmt.Fprintln(w, "  (none)"); err != nil {
-			return err
+			return errors.Wrap(err, "write empty conflicts marker")
 		}
 	} else {
-		for _, kb := range exp.Conflicts {
+		for _, kb := range conflicts {
 			if _, err := fmt.Fprintf(w, "  %s\n", kb); err != nil {
-				return err
+				return errors.Wrapf(err, "write conflict %s", kb)
 			}
 		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
-		return err
+		return errors.Wrap(err, "write conflicts trailing newline")
 	}
+	return nil
+}
 
+func writeKBExpandChains(w io.Writer, exp *microsoft.ExpandResult, classify func(string) string) error {
 	if _, err := fmt.Fprintln(w, "Supersession chains:"); err != nil {
-		return err
+		return errors.Wrap(err, "write chains header")
 	}
 
-	roots := make([]string, 0, len(exp.Inputs.Applied)+len(exp.Inputs.Unapplied))
-	rootSeen := make(map[string]struct{})
-	for _, kb := range exp.Inputs.Applied {
-		if _, ok := rootSeen[kb]; ok {
-			continue
-		}
-		rootSeen[kb] = struct{}{}
-		roots = append(roots, kb)
-	}
-	for _, kb := range exp.Inputs.Unapplied {
-		if _, ok := rootSeen[kb]; ok {
-			continue
-		}
-		rootSeen[kb] = struct{}{}
-		roots = append(roots, kb)
-	}
+	roots := dedupedRoots(exp.Inputs.Applied, exp.Inputs.Unapplied)
 
-	// incoming is the reverse of exp.Edges: incoming[X] lists edges whose To
-	// is X, with To rewritten to point at the original "from" KB. Walking
-	// incoming from a root surfaces the older KBs that root supersedes
-	// (either via Supersedes on root, or via SupersededBy on those older
-	// KBs). Without this, an input KB that sits at the newer end of its
-	// chain would render with no children even though it covers older KBs.
+	// incoming is the reverse of exp.Edges: incoming[X] lists edges whose
+	// To is X, with To rewritten to point at the original "from" KB.
+	// Walking incoming from a root surfaces the older KBs that root
+	// supersedes (either via Supersedes on root, or via SupersededBy on
+	// those older KBs). Without this, an input KB that sits at the newer
+	// end of its chain would render with no children even though it
+	// covers older KBs.
 	incoming := make(map[string][]microsoft.ExpandEdge, len(exp.Edges))
 	for from, es := range exp.Edges {
 		for _, e := range es {
@@ -878,6 +912,20 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []s
 			})
 		}
 	}
+	// The outer range over exp.Edges visits "from" keys in map-iteration
+	// order, so incoming[X] is appended in a non-deterministic order even
+	// though each exp.Edges[from] is already sorted. Sort each value slice
+	// to stabilise the "Supersedes:" section across runs.
+	for _, es := range incoming {
+		slices.SortFunc(es, func(a, b microsoft.ExpandEdge) int {
+			return cmp.Or(
+				cmp.Compare(a.To, b.To),
+				cmp.Compare(string(a.Source), string(b.Source)),
+				cmp.Compare(int(a.Level), int(b.Level)),
+				cmp.Compare(a.UpdateID, b.UpdateID),
+			)
+		})
+	}
 
 	// emittedSubtree tracks nodes whose subtrees have already been printed
 	// in this run. The first occurrence of a KB renders fully; subsequent
@@ -888,89 +936,76 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []s
 	emittedSubtree := make(map[string]struct{})
 	for _, root := range roots {
 		if _, err := fmt.Fprintf(w, "\n  %s  %s\n", root, classify(root)); err != nil {
-			return err
+			return errors.Wrapf(err, "write root %s", root)
 		}
 		emittedSubtree[root] = struct{}{}
 
 		hasForward := len(exp.Edges[root]) > 0
 		hasBackward := len(incoming[root]) > 0
-
-		// When a root has neither direction (e.g., the input KB is unknown
-		// to the database), keep the output minimal: just the root line.
 		if !hasForward && !hasBackward {
 			continue
 		}
-
 		if hasForward {
 			if _, err := fmt.Fprintln(w, "    Superseded by:"); err != nil {
-				return err
+				return errors.Wrapf(err, "write Superseded by header for root %s", root)
 			}
 			if err := writeKBExpandSubtree(w, exp.Edges, classify, root, "      ", emittedSubtree); err != nil {
-				return err
+				return errors.Wrapf(err, "write Superseded by subtree for root %s", root)
 			}
 		}
 		if hasBackward {
 			if _, err := fmt.Fprintln(w, "    Supersedes:"); err != nil {
-				return err
+				return errors.Wrapf(err, "write Supersedes header for root %s", root)
 			}
 			if err := writeKBExpandSubtree(w, incoming, classify, root, "      ", emittedSubtree); err != nil {
-				return err
+				return errors.Wrapf(err, "write Supersedes subtree for root %s", root)
 			}
 		}
 	}
-
-	if _, err := fmt.Fprintln(w); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintln(w, "Result:"); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  Covered:   %s\n", joinSpace(exp.Covered)); err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(w, "  Unapplied: %s\n", joinSpace(exp.Unapplied)); err != nil {
-		return err
-	}
-
-	if len(releases) > 0 {
-		if _, err := fmt.Fprintln(w); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, "Release filter (%s):\n", formatReleases(releases)); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, "  Covered after filter:   %s\n", joinSpace(coveredAfter)); err != nil {
-			return err
-		}
-		if _, err := fmt.Fprintf(w, "  Unapplied after filter: %s\n", joinSpace(unappliedAfter)); err != nil {
-			return err
-		}
-		dropped := append(append([]string{}, coveredDropped...), unappliedDropped...)
-		slices.Sort(dropped)
-		dropped = slices.Compact(dropped)
-		if len(dropped) == 0 {
-			if _, err := fmt.Fprintln(w, "  Dropped:                (none)"); err != nil {
-				return err
-			}
-		} else {
-			if _, err := fmt.Fprintf(w, "  Dropped:                %s\n", joinSpace(dropped)); err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
+}
+
+func writeKBExpandResult(w io.Writer, exp *microsoft.ExpandResult) error {
+	if _, err := fmt.Fprintf(w, "\nResult:\n  Covered:   %s\n  Unapplied: %s\n", joinKBList(exp.Covered), joinKBList(exp.Unapplied)); err != nil {
+		return errors.Wrap(err, "write result section")
+	}
+	return nil
+}
+
+func writeKBExpandFilter(w io.Writer, releases, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped []string) error {
+	dropped := append(append([]string{}, coveredDropped...), unappliedDropped...)
+	slices.Sort(dropped)
+	dropped = slices.Compact(dropped)
+	if _, err := fmt.Fprintf(w, "\nRelease filter (%s):\n  Covered after filter:   %s\n  Unapplied after filter: %s\n  Dropped:                %s\n",
+		formatReleases(releases),
+		joinKBList(coveredAfter),
+		joinKBList(unappliedAfter),
+		joinKBList(dropped),
+	); err != nil {
+		return errors.Wrap(err, "write filter section")
+	}
+	return nil
+}
+
+func dedupedRoots(applied, unapplied []string) []string {
+	// applied/unapplied echo raw user input (Inputs.Applied/Unapplied), so
+	// drop empty entries here — ExpandKBs treats them as inert at walk
+	// time, and rendering a blank "Supersession chains:" root would be
+	// misleading.
+	roots := slices.DeleteFunc(slices.Concat(applied, unapplied), func(s string) bool { return s == "" })
+	slices.Sort(roots)
+	return slices.Compact(roots)
 }
 
 func formatReleases(releases []string) string {
 	if len(releases) == 1 {
 		return fmt.Sprintf("%q", releases[0])
 	}
-	parts := make([]string, len(releases))
+	quoted := make([]string, len(releases))
 	for i, r := range releases {
-		parts[i] = fmt.Sprintf("%q", r)
+		quoted[i] = fmt.Sprintf("%q", r)
 	}
-	return "[" + joinComma(parts) + "]"
+	return fmt.Sprintf("[%s]", strings.Join(quoted, ", "))
 }
 
 // writeKBExpandSubtree walks the adjacency map from the given node and
@@ -981,16 +1016,10 @@ func formatReleases(releases []string) string {
 // relationship regardless of direction.
 func writeKBExpandSubtree(w io.Writer, adj map[string][]microsoft.ExpandEdge, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {
 	edges := adj[from]
-	if len(edges) == 0 {
-		return nil
-	}
 	for i, e := range edges {
-		last := i == len(edges)-1
-		branch := "├─"
-		nextIndent := indent + "│   "
-		if last {
-			branch = "└─"
-			nextIndent = indent + "    "
+		branch, nextIndent := "├─", fmt.Sprintf("%s│   ", indent)
+		if i == len(edges)-1 {
+			branch, nextIndent = "└─", fmt.Sprintf("%s    ", indent)
 		}
 		var srcLabel string
 		switch e.Level {
@@ -1003,16 +1032,16 @@ func writeKBExpandSubtree(w io.Writer, adj map[string][]microsoft.ExpandEdge, cl
 		}
 		if _, ok := emittedSubtree[e.To]; ok {
 			if _, err := fmt.Fprintf(w, "%s%s [%s] %s  (→ see above)\n", indent, branch, srcLabel, e.To); err != nil {
-				return err
+				return errors.Wrapf(err, "write subtree edge %s -> %s", from, e.To)
 			}
 			continue
 		}
 		if _, err := fmt.Fprintf(w, "%s%s [%s] %s  %s\n", indent, branch, srcLabel, e.To, classify(e.To)); err != nil {
-			return err
+			return errors.Wrapf(err, "write subtree edge %s -> %s", from, e.To)
 		}
 		emittedSubtree[e.To] = struct{}{}
 		if err := writeKBExpandSubtree(w, adj, classify, e.To, nextIndent, emittedSubtree); err != nil {
-			return err
+			return errors.Wrapf(err, "walk subtree under %s", e.To)
 		}
 	}
 	return nil
@@ -1026,27 +1055,13 @@ func toSet(ss []string) map[string]struct{} {
 	return m
 }
 
-func joinSpace(ss []string) string {
-	if len(ss) == 0 {
+func joinKBList(ss []string) string {
+	// Some callers pass raw Inputs.Applied/Unapplied which may contain
+	// "" entries (ExpandKBs skips them but echoes the input verbatim).
+	// Filter on a clone to avoid mutating the caller's slice.
+	filtered := slices.DeleteFunc(slices.Clone(ss), func(s string) bool { return s == "" })
+	if len(filtered) == 0 {
 		return "(none)"
 	}
-	out := ""
-	for i, s := range ss {
-		if i > 0 {
-			out += " "
-		}
-		out += s
-	}
-	return out
-}
-
-func joinComma(ss []string) string {
-	out := ""
-	for i, s := range ss {
-		if i > 0 {
-			out += ", "
-		}
-		out += s
-	}
-	return out
+	return strings.Join(filtered, " ")
 }

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -2,6 +2,8 @@ package search
 
 import (
 	"encoding/json/v2"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -18,6 +20,7 @@ import (
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
 	dbTypes "github.com/MaineK00n/vuls2/pkg/db/session/types"
+	"github.com/MaineK00n/vuls2/pkg/detect/ospkg/microsoft"
 	utilos "github.com/MaineK00n/vuls2/pkg/util/os"
 )
 
@@ -634,4 +637,331 @@ func SearchKBVuln(queries []string, datasources []sourceTypes.SourceID, opts ...
 	}
 
 	return nil
+}
+
+// KBExpandResult is the JSON-serialisable form of a kb-expand run.
+type KBExpandResult struct {
+	Inputs                      KBExpandInputs `json:"inputs"`
+	Covered                     []string       `json:"covered"`
+	Unapplied                   []string       `json:"unapplied"`
+	Conflicts                   []string       `json:"conflicts,omitempty"`
+	Release                     string         `json:"release,omitempty"`
+	CoveredAfterReleaseFilter   []string       `json:"covered_after_release_filter,omitempty"`
+	UnappliedAfterReleaseFilter []string       `json:"unapplied_after_release_filter,omitempty"`
+	DroppedByRelease            *KBExpandDrop  `json:"dropped_by_release,omitempty"`
+}
+
+type KBExpandInputs struct {
+	Applied   []string `json:"applied,omitempty"`
+	Unapplied []string `json:"unapplied,omitempty"`
+}
+
+type KBExpandDrop struct {
+	Covered   []string `json:"covered,omitempty"`
+	Unapplied []string `json:"unapplied,omitempty"`
+}
+
+// SearchKBExpand expands the given Applied/Unapplied KB inputs through
+// Microsoft KB supersession chains using the same logic detect uses, and
+// reports the resulting Covered/Unapplied classification. When release is
+// non-empty, also applies the same release filter detect applies and reports
+// what was dropped. When explain is true, renders a human-readable tree
+// instead of JSON.
+func SearchKBExpand(applied []string, unapplied []string, release string, explain bool, opts ...Option) error {
+	options := &options{
+		dbtype:      "boltdb",
+		dbpath:      filepath.Join(utilos.UserCacheDir(), "vuls.db"),
+		storageopts: session.StorageOptions{BoltDB: bolt.DefaultOptions},
+		debug:       false,
+	}
+	for _, o := range opts {
+		o.apply(options)
+	}
+
+	s, err := (&session.Config{
+		Type:    options.dbtype,
+		Path:    options.dbpath,
+		Debug:   options.debug,
+		Options: options.storageopts,
+	}).New()
+	if err != nil {
+		return errors.Wrap(err, "new db connection")
+	}
+
+	if err := s.Storage().Open(); err != nil {
+		return errors.Wrap(err, "open db connection")
+	}
+	defer s.Storage().Close()
+
+	slog.Info("Get Metadata")
+	meta, err := s.Storage().GetMetadata()
+	if err != nil || meta == nil {
+		return errors.Wrap(err, "get metadata")
+	}
+	sv, err := session.SchemaVersion(options.dbtype)
+	if err != nil {
+		return errors.Wrap(err, "get schema version")
+	}
+	if meta.SchemaVersion != sv {
+		return errors.Errorf("unexpected schema version. expected: %d, actual: %d", sv, meta.SchemaVersion)
+	}
+
+	slog.Info("Expand Microsoft KB", "applied", applied, "unapplied", unapplied)
+	exp, err := microsoft.ExpandKBs(s.Storage(), applied, unapplied)
+	if err != nil {
+		return errors.Wrap(err, "expand microsoft kb")
+	}
+
+	var (
+		coveredAfter, unappliedAfter     []string
+		coveredDropped, unappliedDropped []string
+	)
+	if release != "" {
+		coveredAfter, coveredDropped, err = microsoft.PartitionKBIDsByRelease(s.Storage(), exp.Covered, release)
+		if err != nil {
+			return errors.Wrap(err, "partition covered KBs by release")
+		}
+		unappliedAfter, unappliedDropped, err = microsoft.PartitionKBIDsByRelease(s.Storage(), exp.Unapplied, release)
+		if err != nil {
+			return errors.Wrap(err, "partition unapplied KBs by release")
+		}
+	}
+
+	if explain {
+		return printKBExpandTree(os.Stdout, exp, release, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped)
+	}
+
+	out := KBExpandResult{
+		Inputs:    KBExpandInputs{Applied: applied, Unapplied: unapplied},
+		Covered:   exp.Covered,
+		Unapplied: exp.Unapplied,
+		Conflicts: exp.Conflicts,
+	}
+	if release != "" {
+		out.Release = release
+		out.CoveredAfterReleaseFilter = coveredAfter
+		out.UnappliedAfterReleaseFilter = unappliedAfter
+		if len(coveredDropped) > 0 || len(unappliedDropped) > 0 {
+			out.DroppedByRelease = &KBExpandDrop{
+				Covered:   coveredDropped,
+				Unapplied: unappliedDropped,
+			}
+		}
+	}
+	if err := json.MarshalWrite(os.Stdout, out); err != nil {
+		return errors.Wrap(err, "encode kb-expand result")
+	}
+	return nil
+}
+
+func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, release string, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped []string) error {
+	appliedSet := toSet(exp.Inputs.Applied)
+	unappliedSet := toSet(exp.Inputs.Unapplied)
+	coveredSet := toSet(exp.Covered)
+	resultUnappliedSet := toSet(exp.Unapplied)
+
+	classify := func(kbid string) string {
+		var tags []string
+		_, isAppliedInput := appliedSet[kbid]
+		_, isUnappliedInput := unappliedSet[kbid]
+		switch {
+		case isAppliedInput && isUnappliedInput:
+			tags = append(tags, "input:applied", "input:unapplied", "conflict→unapplied")
+		case isAppliedInput:
+			tags = append(tags, "input:applied")
+		case isUnappliedInput:
+			tags = append(tags, "input:unapplied")
+		default:
+			tags = append(tags, "discovered")
+		}
+		if _, ok := coveredSet[kbid]; ok {
+			tags = append(tags, "covered")
+		}
+		if _, ok := resultUnappliedSet[kbid]; ok {
+			tags = append(tags, "unapplied")
+		}
+		return fmt.Sprintf("[%s]", joinComma(tags))
+	}
+
+	if _, err := fmt.Fprintln(w, "Inputs:"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Applied:   %s\n", joinSpace(exp.Inputs.Applied)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Unapplied: %s\n", joinSpace(exp.Inputs.Unapplied)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "Conflicts (in both Applied & Unapplied → treated as Unapplied):"); err != nil {
+		return err
+	}
+	if len(exp.Conflicts) == 0 {
+		if _, err := fmt.Fprintln(w, "  (none)"); err != nil {
+			return err
+		}
+	} else {
+		for _, kb := range exp.Conflicts {
+			if _, err := fmt.Fprintf(w, "  %s\n", kb); err != nil {
+				return err
+			}
+		}
+	}
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(w, "Supersession chains:"); err != nil {
+		return err
+	}
+
+	roots := make([]string, 0, len(exp.Inputs.Applied)+len(exp.Inputs.Unapplied))
+	rootSeen := make(map[string]struct{})
+	for _, kb := range exp.Inputs.Applied {
+		if _, ok := rootSeen[kb]; ok {
+			continue
+		}
+		rootSeen[kb] = struct{}{}
+		roots = append(roots, kb)
+	}
+	for _, kb := range exp.Inputs.Unapplied {
+		if _, ok := rootSeen[kb]; ok {
+			continue
+		}
+		rootSeen[kb] = struct{}{}
+		roots = append(roots, kb)
+	}
+
+	// emittedSubtree tracks nodes whose subtrees have already been printed
+	// in this run. The first occurrence of a KB renders fully; subsequent
+	// occurrences (across siblings or from later roots) are collapsed with
+	// "(→ see above)" to keep the tree readable in the presence of multiple
+	// data sources or supersession cycles.
+	emittedSubtree := make(map[string]struct{})
+	for _, root := range roots {
+		if _, err := fmt.Fprintf(w, "\n  %s  %s\n", root, classify(root)); err != nil {
+			return err
+		}
+		emittedSubtree[root] = struct{}{}
+		if err := writeKBExpandSubtree(w, exp, classify, root, "  ", emittedSubtree); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprintln(w); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(w, "Result:"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Covered:   %s\n", joinSpace(exp.Covered)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(w, "  Unapplied: %s\n", joinSpace(exp.Unapplied)); err != nil {
+		return err
+	}
+
+	if release != "" {
+		if _, err := fmt.Fprintln(w); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "Release filter (%q):\n", release); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "  Covered after filter:   %s\n", joinSpace(coveredAfter)); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(w, "  Unapplied after filter: %s\n", joinSpace(unappliedAfter)); err != nil {
+			return err
+		}
+		dropped := append(append([]string{}, coveredDropped...), unappliedDropped...)
+		slices.Sort(dropped)
+		dropped = slices.Compact(dropped)
+		if len(dropped) == 0 {
+			if _, err := fmt.Fprintln(w, "  Dropped:                (none)"); err != nil {
+				return err
+			}
+		} else {
+			if _, err := fmt.Fprintf(w, "  Dropped:                %s\n", joinSpace(dropped)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func writeKBExpandSubtree(w io.Writer, exp *microsoft.ExpandResult, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {
+	edges := exp.Edges[from]
+	if len(edges) == 0 {
+		return nil
+	}
+	for i, e := range edges {
+		last := i == len(edges)-1
+		branch := "├─"
+		nextIndent := indent + "│   "
+		if last {
+			branch = "└─"
+			nextIndent = indent + "    "
+		}
+		var srcLabel string
+		switch e.Level {
+		case microsoft.ExpandEdgeLevelKB:
+			srcLabel = fmt.Sprintf("%s, KB-level", e.Source)
+		case microsoft.ExpandEdgeLevelUpdate:
+			srcLabel = fmt.Sprintf("%s, Update %s", e.Source, e.UpdateID)
+		default:
+			srcLabel = string(e.Source)
+		}
+		if _, ok := emittedSubtree[e.To]; ok {
+			if _, err := fmt.Fprintf(w, "%s%s [%s] %s  (→ see above)\n", indent, branch, srcLabel, e.To); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(w, "%s%s [%s] %s  %s\n", indent, branch, srcLabel, e.To, classify(e.To)); err != nil {
+			return err
+		}
+		emittedSubtree[e.To] = struct{}{}
+		if err := writeKBExpandSubtree(w, exp, classify, e.To, nextIndent, emittedSubtree); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func toSet(ss []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		m[s] = struct{}{}
+	}
+	return m
+}
+
+func joinSpace(ss []string) string {
+	if len(ss) == 0 {
+		return "(none)"
+	}
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += " "
+		}
+		out += s
+	}
+	return out
+}
+
+func joinComma(ss []string) string {
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += ", "
+		}
+		out += s
+	}
+	return out
 }

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -641,14 +641,15 @@ func SearchKBVuln(queries []string, datasources []sourceTypes.SourceID, opts ...
 
 // KBExpandResult is the JSON-serialisable form of a kb-expand run.
 type KBExpandResult struct {
-	Inputs                      KBExpandInputs `json:"inputs"`
-	Covered                     []string       `json:"covered"`
-	Unapplied                   []string       `json:"unapplied"`
-	Conflicts                   []string       `json:"conflicts,omitempty"`
-	Release                     string         `json:"release,omitempty"`
-	CoveredAfterReleaseFilter   []string       `json:"covered_after_release_filter,omitempty"`
-	UnappliedAfterReleaseFilter []string       `json:"unapplied_after_release_filter,omitempty"`
-	DroppedByRelease            *KBExpandDrop  `json:"dropped_by_release,omitempty"`
+	Inputs                      KBExpandInputs         `json:"inputs"`
+	DataSources                 []sourceTypes.SourceID `json:"datasources,omitempty"`
+	Covered                     []string               `json:"covered"`
+	Unapplied                   []string               `json:"unapplied"`
+	Conflicts                   []string               `json:"conflicts,omitempty"`
+	Releases                    []string               `json:"releases,omitempty"`
+	CoveredAfterReleaseFilter   []string               `json:"covered_after_release_filter,omitempty"`
+	UnappliedAfterReleaseFilter []string               `json:"unapplied_after_release_filter,omitempty"`
+	DroppedByRelease            *KBExpandDrop          `json:"dropped_by_release,omitempty"`
 }
 
 type KBExpandInputs struct {
@@ -661,13 +662,24 @@ type KBExpandDrop struct {
 	Unapplied []string `json:"unapplied,omitempty"`
 }
 
+// KBExpandRequest captures the inputs and filters for a kb-expand run.
+type KBExpandRequest struct {
+	Applied     []string
+	Unapplied   []string
+	Releases    []string
+	DataSources []sourceTypes.SourceID
+	Explain     bool
+}
+
 // SearchKBExpand expands the given Applied/Unapplied KB inputs through
 // Microsoft KB supersession chains using the same logic detect uses, and
-// reports the resulting Covered/Unapplied classification. When release is
-// non-empty, also applies the same release filter detect applies and reports
-// what was dropped. When explain is true, renders a human-readable tree
-// instead of JSON.
-func SearchKBExpand(applied []string, unapplied []string, release string, explain bool, opts ...Option) error {
+// reports the resulting Covered/Unapplied classification. When Releases is
+// non-empty, also applies the same release filter detect applies (with union
+// semantics across releases) and reports what was dropped. When DataSources
+// is non-empty, only edges and products contributed by those sources are
+// considered. When Explain is true, renders a human-readable tree instead
+// of JSON.
+func SearchKBExpand(req KBExpandRequest, opts ...Option) error {
 	options := &options{
 		dbtype:      "boltdb",
 		dbpath:      filepath.Join(utilos.UserCacheDir(), "vuls.db"),
@@ -706,8 +718,12 @@ func SearchKBExpand(applied []string, unapplied []string, release string, explai
 		return errors.Errorf("unexpected schema version. expected: %d, actual: %d", sv, meta.SchemaVersion)
 	}
 
-	slog.Info("Expand Microsoft KB", "applied", applied, "unapplied", unapplied)
-	exp, err := microsoft.ExpandKBs(s.Storage(), applied, unapplied)
+	slog.Info("Expand Microsoft KB", "applied", req.Applied, "unapplied", req.Unapplied, "datasources", req.DataSources)
+	expandOpts := []microsoft.ExpandOption{}
+	if len(req.DataSources) > 0 {
+		expandOpts = append(expandOpts, microsoft.WithExpandDataSources(req.DataSources))
+	}
+	exp, err := microsoft.ExpandKBs(s.Storage(), req.Applied, req.Unapplied, expandOpts...)
 	if err != nil {
 		return errors.Wrap(err, "expand microsoft kb")
 	}
@@ -716,29 +732,30 @@ func SearchKBExpand(applied []string, unapplied []string, release string, explai
 		coveredAfter, unappliedAfter     []string
 		coveredDropped, unappliedDropped []string
 	)
-	if release != "" {
-		coveredAfter, coveredDropped, err = microsoft.PartitionKBIDsByRelease(s.Storage(), exp.Covered, release)
+	if len(req.Releases) > 0 {
+		coveredAfter, coveredDropped, err = microsoft.PartitionKBIDsByReleases(s.Storage(), exp.Covered, req.Releases, expandOpts...)
 		if err != nil {
 			return errors.Wrap(err, "partition covered KBs by release")
 		}
-		unappliedAfter, unappliedDropped, err = microsoft.PartitionKBIDsByRelease(s.Storage(), exp.Unapplied, release)
+		unappliedAfter, unappliedDropped, err = microsoft.PartitionKBIDsByReleases(s.Storage(), exp.Unapplied, req.Releases, expandOpts...)
 		if err != nil {
 			return errors.Wrap(err, "partition unapplied KBs by release")
 		}
 	}
 
-	if explain {
-		return printKBExpandTree(os.Stdout, exp, release, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped)
+	if req.Explain {
+		return printKBExpandTree(os.Stdout, exp, req.DataSources, req.Releases, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped)
 	}
 
 	out := KBExpandResult{
-		Inputs:    KBExpandInputs{Applied: applied, Unapplied: unapplied},
-		Covered:   exp.Covered,
-		Unapplied: exp.Unapplied,
-		Conflicts: exp.Conflicts,
+		Inputs:      KBExpandInputs{Applied: req.Applied, Unapplied: req.Unapplied},
+		DataSources: req.DataSources,
+		Covered:     exp.Covered,
+		Unapplied:   exp.Unapplied,
+		Conflicts:   exp.Conflicts,
 	}
-	if release != "" {
-		out.Release = release
+	if len(req.Releases) > 0 {
+		out.Releases = req.Releases
 		out.CoveredAfterReleaseFilter = coveredAfter
 		out.UnappliedAfterReleaseFilter = unappliedAfter
 		if len(coveredDropped) > 0 || len(unappliedDropped) > 0 {
@@ -754,7 +771,7 @@ func SearchKBExpand(applied []string, unapplied []string, release string, explai
 	return nil
 }
 
-func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, release string, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped []string) error {
+func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []sourceTypes.SourceID, releases []string, coveredAfter, unappliedAfter, coveredDropped, unappliedDropped []string) error {
 	appliedSet := toSet(exp.Inputs.Applied)
 	unappliedSet := toSet(exp.Inputs.Unapplied)
 	coveredSet := toSet(exp.Covered)
@@ -791,6 +808,15 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, release string,
 	}
 	if _, err := fmt.Fprintf(w, "  Unapplied: %s\n", joinSpace(exp.Inputs.Unapplied)); err != nil {
 		return err
+	}
+	if len(datasources) > 0 {
+		dsStrs := make([]string, len(datasources))
+		for i, d := range datasources {
+			dsStrs[i] = string(d)
+		}
+		if _, err := fmt.Fprintf(w, "  Data sources: %s\n", joinSpace(dsStrs)); err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return err
@@ -864,11 +890,11 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, release string,
 		return err
 	}
 
-	if release != "" {
+	if len(releases) > 0 {
 		if _, err := fmt.Fprintln(w); err != nil {
 			return err
 		}
-		if _, err := fmt.Fprintf(w, "Release filter (%q):\n", release); err != nil {
+		if _, err := fmt.Fprintf(w, "Release filter (%s):\n", formatReleases(releases)); err != nil {
 			return err
 		}
 		if _, err := fmt.Fprintf(w, "  Covered after filter:   %s\n", joinSpace(coveredAfter)); err != nil {
@@ -892,6 +918,17 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, release string,
 	}
 
 	return nil
+}
+
+func formatReleases(releases []string) string {
+	if len(releases) == 1 {
+		return fmt.Sprintf("%q", releases[0])
+	}
+	parts := make([]string, len(releases))
+	for i, r := range releases {
+		parts[i] = fmt.Sprintf("%q", r)
+	}
+	return "[" + joinComma(parts) + "]"
 }
 
 func writeKBExpandSubtree(w io.Writer, exp *microsoft.ExpandResult, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -861,19 +861,61 @@ func printKBExpandTree(w io.Writer, exp *microsoft.ExpandResult, datasources []s
 		roots = append(roots, kb)
 	}
 
+	// incoming is the reverse of exp.Edges: incoming[X] lists edges whose To
+	// is X, with To rewritten to point at the original "from" KB. Walking
+	// incoming from a root surfaces the older KBs that root supersedes
+	// (either via Supersedes on root, or via SupersededBy on those older
+	// KBs). Without this, an input KB that sits at the newer end of its
+	// chain would render with no children even though it covers older KBs.
+	incoming := make(map[string][]microsoft.ExpandEdge, len(exp.Edges))
+	for from, es := range exp.Edges {
+		for _, e := range es {
+			incoming[e.To] = append(incoming[e.To], microsoft.ExpandEdge{
+				To:       from,
+				Source:   e.Source,
+				Level:    e.Level,
+				UpdateID: e.UpdateID,
+			})
+		}
+	}
+
 	// emittedSubtree tracks nodes whose subtrees have already been printed
 	// in this run. The first occurrence of a KB renders fully; subsequent
-	// occurrences (across siblings or from later roots) are collapsed with
-	// "(→ see above)" to keep the tree readable in the presence of multiple
-	// data sources or supersession cycles.
+	// occurrences (across siblings, between forward/backward sections, or
+	// from later roots) are collapsed with "(→ see above)" to keep the
+	// tree readable in the presence of multiple data sources or
+	// supersession cycles.
 	emittedSubtree := make(map[string]struct{})
 	for _, root := range roots {
 		if _, err := fmt.Fprintf(w, "\n  %s  %s\n", root, classify(root)); err != nil {
 			return err
 		}
 		emittedSubtree[root] = struct{}{}
-		if err := writeKBExpandSubtree(w, exp, classify, root, "  ", emittedSubtree); err != nil {
-			return err
+
+		hasForward := len(exp.Edges[root]) > 0
+		hasBackward := len(incoming[root]) > 0
+
+		// When a root has neither direction (e.g., the input KB is unknown
+		// to the database), keep the output minimal: just the root line.
+		if !hasForward && !hasBackward {
+			continue
+		}
+
+		if hasForward {
+			if _, err := fmt.Fprintln(w, "    Superseded by:"); err != nil {
+				return err
+			}
+			if err := writeKBExpandSubtree(w, exp.Edges, classify, root, "      ", emittedSubtree); err != nil {
+				return err
+			}
+		}
+		if hasBackward {
+			if _, err := fmt.Fprintln(w, "    Supersedes:"); err != nil {
+				return err
+			}
+			if err := writeKBExpandSubtree(w, incoming, classify, root, "      ", emittedSubtree); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -931,8 +973,14 @@ func formatReleases(releases []string) string {
 	return "[" + joinComma(parts) + "]"
 }
 
-func writeKBExpandSubtree(w io.Writer, exp *microsoft.ExpandResult, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {
-	edges := exp.Edges[from]
+// writeKBExpandSubtree walks the adjacency map from the given node and
+// writes each reachable edge as a tree branch. The adjacency map can be
+// the forward map (exp.Edges) for the "Superseded by" view or the reverse
+// map for the "Supersedes" view; the rendering is identical because the
+// edge metadata (source, level, update id) describes the same logical
+// relationship regardless of direction.
+func writeKBExpandSubtree(w io.Writer, adj map[string][]microsoft.ExpandEdge, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {
+	edges := adj[from]
 	if len(edges) == 0 {
 		return nil
 	}
@@ -963,7 +1011,7 @@ func writeKBExpandSubtree(w io.Writer, exp *microsoft.ExpandResult, classify fun
 			return err
 		}
 		emittedSubtree[e.To] = struct{}{}
-		if err := writeKBExpandSubtree(w, exp, classify, e.To, nextIndent, emittedSubtree); err != nil {
+		if err := writeKBExpandSubtree(w, adj, classify, e.To, nextIndent, emittedSubtree); err != nil {
 			return err
 		}
 	}

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -1,0 +1,137 @@
+package search
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/MaineK00n/vuls2/pkg/detect/ospkg/microsoft"
+)
+
+func TestPrintKBExpandTree(t *testing.T) {
+	tests := []struct {
+		name             string
+		exp              *microsoft.ExpandResult
+		release          string
+		coveredAfter     []string
+		unappliedAfter   []string
+		coveredDropped   []string
+		unappliedDropped []string
+		wantContains     []string
+		wantNotContains  []string
+	}{
+		{
+			name: "single applied root with KB-level chain",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+			},
+			wantContains: []string{
+				"Inputs:",
+				"Applied:   5000802",
+				"Unapplied: (none)",
+				"Conflicts (in both Applied & Unapplied → treated as Unapplied):",
+				"(none)",
+				"Supersession chains:",
+				"5000802  [input:applied, covered]",
+				"└─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
+				"Result:",
+				"Covered:   5000802",
+				"Unapplied: 5001330",
+			},
+			wantNotContains: []string{"Release filter"},
+		},
+		{
+			name: "applied input that is also unapplied input is flagged conflict",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}, Unapplied: []string{"5000802"}},
+				Covered:   nil,
+				Unapplied: []string{"5000802"},
+				Conflicts: []string{"5000802"},
+			},
+			wantContains: []string{
+				"Conflicts (in both Applied & Unapplied → treated as Unapplied):",
+				"5000802",
+				"5000802  [input:applied, input:unapplied, conflict→unapplied, unapplied]",
+			},
+		},
+		{
+			name: "edges from multiple data sources show source attribution",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {
+						{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB},
+						{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "abc-123"},
+					},
+				},
+			},
+			wantContains: []string{
+				"[microsoft-cvrf, KB-level] 5001330",
+				"[microsoft-msuc, Update abc-123] 5001330",
+				"(→ see above)",
+			},
+		},
+		{
+			name: "release filter section is rendered when release is set",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330", "9999999"},
+			},
+			release:          "Windows 10 Version 22H2 for x64-based Systems",
+			coveredAfter:     []string{"5000802"},
+			unappliedAfter:   []string{"5001330"},
+			unappliedDropped: []string{"9999999"},
+			wantContains: []string{
+				`Release filter ("Windows 10 Version 22H2 for x64-based Systems"):`,
+				"Covered after filter:   5000802",
+				"Unapplied after filter: 5001330",
+				"Dropped:                9999999",
+			},
+		},
+		{
+			name: "cycle in supersession is broken with see-above",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"A"}},
+				Covered:   []string{"A", "B"},
+				Unapplied: nil,
+				Edges: map[string][]microsoft.ExpandEdge{
+					"A": {{To: "B", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"B": {{To: "A", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+			},
+			wantContains: []string{
+				"A  [input:applied, covered]",
+				"└─ [microsoft-cvrf, KB-level] B  [discovered, covered]",
+				"(→ see above)",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			if err := printKBExpandTree(&buf, tt.exp, tt.release, tt.coveredAfter, tt.unappliedAfter, tt.coveredDropped, tt.unappliedDropped); err != nil {
+				t.Fatalf("printKBExpandTree() error = %v", err)
+			}
+			got := buf.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("output missing %q\nfull output:\n%s", want, got)
+				}
+			}
+			for _, notWant := range tt.wantNotContains {
+				if strings.Contains(got, notWant) {
+					t.Errorf("output unexpectedly contains %q\nfull output:\n%s", notWant, got)
+				}
+			}
+		})
+	}
+}

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/detect/ospkg/microsoft"
 )
 
@@ -12,7 +13,8 @@ func TestPrintKBExpandTree(t *testing.T) {
 	tests := []struct {
 		name             string
 		exp              *microsoft.ExpandResult
-		release          string
+		datasources      []sourceTypes.SourceID
+		releases         []string
 		coveredAfter     []string
 		unappliedAfter   []string
 		coveredDropped   []string
@@ -43,7 +45,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"Covered:   5000802",
 				"Unapplied: 5001330",
 			},
-			wantNotContains: []string{"Release filter"},
+			wantNotContains: []string{"Release filter", "Data sources:"},
 		},
 		{
 			name: "applied input that is also unapplied input is flagged conflict",
@@ -79,13 +81,13 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 		},
 		{
-			name: "release filter section is rendered when release is set",
+			name: "release filter section is rendered when a single release is set",
 			exp: &microsoft.ExpandResult{
 				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
 				Covered:   []string{"5000802"},
 				Unapplied: []string{"5001330", "9999999"},
 			},
-			release:          "Windows 10 Version 22H2 for x64-based Systems",
+			releases:         []string{"Windows 10 Version 22H2 for x64-based Systems"},
 			coveredAfter:     []string{"5000802"},
 			unappliedAfter:   []string{"5001330"},
 			unappliedDropped: []string{"9999999"},
@@ -94,6 +96,38 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"Covered after filter:   5000802",
 				"Unapplied after filter: 5001330",
 				"Dropped:                9999999",
+			},
+		},
+		{
+			name: "release filter renders bracketed list when multiple releases are set",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330"},
+			},
+			releases: []string{
+				"Windows 10 Version 22H2 for x64-based Systems",
+				"Windows 11 Version 23H2 for x64-based Systems",
+			},
+			coveredAfter:   []string{"5000802"},
+			unappliedAfter: []string{"5001330"},
+			wantContains: []string{
+				`Release filter (["Windows 10 Version 22H2 for x64-based Systems", "Windows 11 Version 23H2 for x64-based Systems"]):`,
+				"Covered after filter:   5000802",
+				"Unapplied after filter: 5001330",
+				"Dropped:                (none)",
+			},
+		},
+		{
+			name: "datasource filter is reflected in the inputs section",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: nil,
+			},
+			datasources: []sourceTypes.SourceID{"microsoft-cvrf", "microsoft-msuc"},
+			wantContains: []string{
+				"Data sources: microsoft-cvrf microsoft-msuc",
 			},
 		},
 		{
@@ -118,7 +152,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := printKBExpandTree(&buf, tt.exp, tt.release, tt.coveredAfter, tt.unappliedAfter, tt.coveredDropped, tt.unappliedDropped); err != nil {
+			if err := printKBExpandTree(&buf, tt.exp, tt.datasources, tt.releases, tt.coveredAfter, tt.unappliedAfter, tt.coveredDropped, tt.unappliedDropped); err != nil {
 				t.Fatalf("printKBExpandTree() error = %v", err)
 			}
 			got := buf.String()

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -40,12 +40,13 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"(none)",
 				"Supersession chains:",
 				"5000802  [input:applied, covered]",
-				"└─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
+				"    Superseded by:",
+				"      └─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
 				"Result:",
 				"Covered:   5000802",
 				"Unapplied: 5001330",
 			},
-			wantNotContains: []string{"Release filter", "Data sources:"},
+			wantNotContains: []string{"Release filter", "Data sources:", "    Supersedes:"},
 		},
 		{
 			name: "applied input that is also unapplied input is flagged conflict",
@@ -75,6 +76,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 				},
 			},
 			wantContains: []string{
+				"    Superseded by:",
 				"[microsoft-cvrf, KB-level] 5001330",
 				"[microsoft-msuc, Update abc-123] 5001330",
 				"(→ see above)",
@@ -131,6 +133,59 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 		},
 		{
+			name: "newest input with Supersedes-only chain shows backward section",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"7000004"}},
+				Covered:   []string{"7000002", "7000003", "7000004"},
+				Unapplied: nil,
+				Edges: map[string][]microsoft.ExpandEdge{
+					"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+			},
+			wantContains: []string{
+				"7000004  [input:applied, covered]",
+				"    Supersedes:",
+				"      └─ [microsoft-cvrf, KB-level] 7000003  [discovered, covered]",
+				"          └─ [microsoft-cvrf, KB-level] 7000002  [discovered, covered]",
+			},
+			wantNotContains: []string{"    Superseded by:"},
+		},
+		{
+			name: "intermediate input renders both Superseded by and Supersedes sections",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"7000003"}},
+				Covered:   []string{"7000002", "7000003"},
+				Unapplied: []string{"7000004"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+			},
+			wantContains: []string{
+				"7000003  [input:applied, covered]",
+				"    Superseded by:",
+				"      └─ [microsoft-cvrf, KB-level] 7000004  [discovered, unapplied]",
+				"    Supersedes:",
+				"      └─ [microsoft-cvrf, KB-level] 7000002  [discovered, covered]",
+			},
+		},
+		{
+			name: "input KB unknown to DB renders as a leaf with no sections",
+			exp: &microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"9999999"}},
+				Covered:   []string{"9999999"},
+				Unapplied: nil,
+			},
+			wantContains: []string{
+				"9999999  [input:applied, covered]",
+			},
+			wantNotContains: []string{
+				"    Superseded by:",
+				"    Supersedes:",
+			},
+		},
+		{
 			name: "cycle in supersession is broken with see-above",
 			exp: &microsoft.ExpandResult{
 				Inputs:    microsoft.ExpandInputs{Applied: []string{"A"}},
@@ -143,7 +198,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 			wantContains: []string{
 				"A  [input:applied, covered]",
-				"└─ [microsoft-cvrf, KB-level] B  [discovered, covered]",
+				"      └─ [microsoft-cvrf, KB-level] B  [discovered, covered]",
 				"(→ see above)",
 			},
 		},

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func TestPrintKBExpandTree(t *testing.T) {
-	tests := []struct {
-		name             string
+	type args struct {
 		exp              *microsoft.ExpandResult
 		datasources      []sourceTypes.SourceID
 		releases         []string
@@ -19,17 +18,23 @@ func TestPrintKBExpandTree(t *testing.T) {
 		unappliedAfter   []string
 		coveredDropped   []string
 		unappliedDropped []string
-		wantContains     []string
-		wantNotContains  []string
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantContains    []string
+		wantNotContains []string
 	}{
 		{
 			name: "single applied root with KB-level chain",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
-				Covered:   []string{"5000802"},
-				Unapplied: []string{"5001330"},
-				Edges: map[string][]microsoft.ExpandEdge{
-					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					},
 				},
 			},
 			wantContains: []string{
@@ -50,11 +55,13 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "applied input that is also unapplied input is flagged conflict",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}, Unapplied: []string{"5000802"}},
-				Covered:   nil,
-				Unapplied: []string{"5000802"},
-				Conflicts: []string{"5000802"},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}, Unapplied: []string{"5000802"}},
+					Covered:   nil,
+					Unapplied: []string{"5000802"},
+					Conflicts: []string{"5000802"},
+				},
 			},
 			wantContains: []string{
 				"Conflicts (in both Applied & Unapplied → treated as Unapplied):",
@@ -64,14 +71,16 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "edges from multiple data sources show source attribution",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
-				Covered:   []string{"5000802"},
-				Unapplied: []string{"5001330"},
-				Edges: map[string][]microsoft.ExpandEdge{
-					"5000802": {
-						{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB},
-						{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "abc-123"},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"5000802": {
+							{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB},
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "abc-123"},
+						},
 					},
 				},
 			},
@@ -84,15 +93,17 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "release filter section is rendered when a single release is set",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
-				Covered:   []string{"5000802"},
-				Unapplied: []string{"5001330", "9999999"},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330", "9999999"},
+				},
+				releases:         []string{"Windows 10 Version 22H2 for x64-based Systems"},
+				coveredAfter:     []string{"5000802"},
+				unappliedAfter:   []string{"5001330"},
+				unappliedDropped: []string{"9999999"},
 			},
-			releases:         []string{"Windows 10 Version 22H2 for x64-based Systems"},
-			coveredAfter:     []string{"5000802"},
-			unappliedAfter:   []string{"5001330"},
-			unappliedDropped: []string{"9999999"},
 			wantContains: []string{
 				`Release filter ("Windows 10 Version 22H2 for x64-based Systems"):`,
 				"Covered after filter:   5000802",
@@ -102,17 +113,19 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "release filter renders bracketed list when multiple releases are set",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
-				Covered:   []string{"5000802"},
-				Unapplied: []string{"5001330"},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+				},
+				releases: []string{
+					"Windows 10 Version 22H2 for x64-based Systems",
+					"Windows 11 Version 23H2 for x64-based Systems",
+				},
+				coveredAfter:   []string{"5000802"},
+				unappliedAfter: []string{"5001330"},
 			},
-			releases: []string{
-				"Windows 10 Version 22H2 for x64-based Systems",
-				"Windows 11 Version 23H2 for x64-based Systems",
-			},
-			coveredAfter:   []string{"5000802"},
-			unappliedAfter: []string{"5001330"},
 			wantContains: []string{
 				`Release filter (["Windows 10 Version 22H2 for x64-based Systems", "Windows 11 Version 23H2 for x64-based Systems"]):`,
 				"Covered after filter:   5000802",
@@ -122,25 +135,29 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "datasource filter is reflected in the inputs section",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
-				Covered:   []string{"5000802"},
-				Unapplied: nil,
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: nil,
+				},
+				datasources: []sourceTypes.SourceID{"microsoft-cvrf", "microsoft-msuc"},
 			},
-			datasources: []sourceTypes.SourceID{"microsoft-cvrf", "microsoft-msuc"},
 			wantContains: []string{
 				"Data sources: microsoft-cvrf microsoft-msuc",
 			},
 		},
 		{
 			name: "newest input with Supersedes-only chain shows backward section",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"7000004"}},
-				Covered:   []string{"7000002", "7000003", "7000004"},
-				Unapplied: nil,
-				Edges: map[string][]microsoft.ExpandEdge{
-					"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
-					"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"7000004"}},
+					Covered:   []string{"7000002", "7000003", "7000004"},
+					Unapplied: nil,
+					Edges: map[string][]microsoft.ExpandEdge{
+						"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+						"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					},
 				},
 			},
 			wantContains: []string{
@@ -153,13 +170,15 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "intermediate input renders both Superseded by and Supersedes sections",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"7000003"}},
-				Covered:   []string{"7000002", "7000003"},
-				Unapplied: []string{"7000004"},
-				Edges: map[string][]microsoft.ExpandEdge{
-					"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
-					"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"7000003"}},
+					Covered:   []string{"7000002", "7000003"},
+					Unapplied: []string{"7000004"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+						"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					},
 				},
 			},
 			wantContains: []string{
@@ -172,10 +191,12 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "input KB unknown to DB renders as a leaf with no sections",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"9999999"}},
-				Covered:   []string{"9999999"},
-				Unapplied: nil,
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"9999999"}},
+					Covered:   []string{"9999999"},
+					Unapplied: nil,
+				},
 			},
 			wantContains: []string{
 				"9999999  [input:applied, covered]",
@@ -187,13 +208,15 @@ func TestPrintKBExpandTree(t *testing.T) {
 		},
 		{
 			name: "cycle in supersession is broken with see-above",
-			exp: &microsoft.ExpandResult{
-				Inputs:    microsoft.ExpandInputs{Applied: []string{"A"}},
-				Covered:   []string{"A", "B"},
-				Unapplied: nil,
-				Edges: map[string][]microsoft.ExpandEdge{
-					"A": {{To: "B", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
-					"B": {{To: "A", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"A"}},
+					Covered:   []string{"A", "B"},
+					Unapplied: nil,
+					Edges: map[string][]microsoft.ExpandEdge{
+						"A": {{To: "B", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+						"B": {{To: "A", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					},
 				},
 			},
 			wantContains: []string{
@@ -202,12 +225,40 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"(→ see above)",
 			},
 		},
+		{
+			// Inputs may echo "" entries that ExpandKBs treated as inert
+			// (e.g. --applied "" --applied 5000802). The renderer must not
+			// emit a blank root in "Supersession chains:" or a stray space
+			// in the Applied / Unapplied joinKBList output.
+			name: "empty KB IDs in inputs are not rendered",
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"", "5000802"}, Unapplied: []string{""}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					},
+				},
+			},
+			wantContains: []string{
+				"Applied:   5000802",
+				"Unapplied: (none)",
+				"5000802  [input:applied, covered]",
+				"      └─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
+			},
+			wantNotContains: []string{
+				"Applied:   \n",      // no stray leading/trailing space from "" entry
+				"Applied:    5000802", // no double-space caused by leading "" in join
+				"\n  \n",              // no blank root line in Supersession chains
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			if err := printKBExpandTree(&buf, tt.exp, tt.datasources, tt.releases, tt.coveredAfter, tt.unappliedAfter, tt.coveredDropped, tt.unappliedDropped); err != nil {
+			if err := printKBExpandTree(&buf, tt.args.exp, tt.args.datasources, tt.args.releases, tt.args.coveredAfter, tt.args.unappliedAfter, tt.args.coveredDropped, tt.args.unappliedDropped); err != nil {
 				t.Fatalf("printKBExpandTree() error = %v", err)
 			}
 			got := buf.String()

--- a/pkg/detect/ospkg/microsoft/export_test.go
+++ b/pkg/detect/ospkg/microsoft/export_test.go
@@ -1,8 +1,6 @@
 package microsoft
 
 var (
-	ClassifyKBs                   = classifyKBs
-	FilterKBIDsByRelease          = filterKBIDsByRelease
 	NormalizeMicrosoftPackageName = normalizeMicrosoftPackageName
 	FilterMicrosoftKBProduct      = filterMicrosoftKBProduct
 	ForwardSupersedersFromApplied = forwardSupersedersFromApplied

--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -25,16 +25,25 @@ import (
 // ExpandResult describes how an input set of Applied/Unapplied KBs is
 // expanded through Microsoft KB supersession chains for vulnerability
 // detection. It carries the inputs, the discovered edges (with data-source
-// attribution), and the final classification used by Detect.
+// attribution), the final classification used by Detect, and the products
+// observed for every visited KB (already restricted to the data-source
+// filter passed to ExpandKBs).
+//
+// Slices are returned in iteration order; callers that need a stable
+// ordering (e.g. for display or comparison) should sort them.
 type ExpandResult struct {
 	Inputs    ExpandInputs
 	Covered   []string
 	Unapplied []string
-	Visited   []string
 	// Edges maps a "from" KB ID (the superseded KB) to the list of edges
 	// pointing at superseding KBs, each annotated with the data source and
 	// whether the edge was reported at KB level or per-update level.
 	Edges map[string][]ExpandEdge
+	// Products maps every visited KB ID to the union of its products
+	// contributed by data sources allowed at expansion time. KBs that were
+	// looked up but not found in the database are absent from this map;
+	// PartitionKBIDsByReleases keeps such KBs to avoid false negatives.
+	Products map[string][]string
 	// Conflicts lists KBs that appeared in both the Applied and Unapplied
 	// inputs. Per the classifier policy, conflicts are treated as Unapplied.
 	Conflicts []string
@@ -70,36 +79,14 @@ type ExpandEdge struct {
 	UpdateID string
 }
 
-// ExpandOption configures KB-expansion helpers (ExpandKBs and
-// PartitionKBIDsByReleases). Options are additive; the zero set of options
-// matches the behaviour Detect uses.
-type ExpandOption func(*expandOptions)
-
-type expandOptions struct {
-	datasources []sourceTypes.SourceID
-}
-
-// WithExpandDataSources restricts KB-expansion (supersession walking and
-// product evaluation) to the given Microsoft data sources. When the list is
-// empty, all sources are considered. Edges and products contributed by a
-// source not in the list are ignored.
-func WithExpandDataSources(ds []sourceTypes.SourceID) ExpandOption {
-	return func(o *expandOptions) { o.datasources = ds }
-}
-
-func newExpandOptions(opts []ExpandOption) *expandOptions {
-	eo := &expandOptions{}
-	for _, o := range opts {
-		o(eo)
-	}
-	return eo
-}
-
-func (o *expandOptions) allowSource(id sourceTypes.SourceID) bool {
-	if len(o.datasources) == 0 {
+// allowMicrosoftKBSource reports whether a Microsoft KB data source should
+// contribute to KB-expansion. An empty datasources slice means "no filter"
+// and every source is allowed.
+func allowMicrosoftKBSource(datasources []sourceTypes.SourceID, id sourceTypes.SourceID) bool {
+	if len(datasources) == 0 {
 		return true
 	}
-	return slices.Contains(o.datasources, id)
+	return slices.Contains(datasources, id)
 }
 
 func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.ScanResult, concurrency int) (map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, error) {
@@ -209,23 +196,21 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 		}
 	}
 
-	coveredKBs, unappliedKBs, err := classifyKBs(s, sr.MicrosoftKB.Applied, sr.MicrosoftKB.Unapplied)
+	exp, err := ExpandKBs(s, sr.MicrosoftKB.Applied, sr.MicrosoftKB.Unapplied, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "classify KBs")
+		return nil, errors.Wrap(err, "expand KBs")
 	}
 
 	// Filter unapplied/covered KBs to only those whose products are relevant
 	// to this host. Without this filter, supersession chain walking can discover
 	// KBs for unrelated products (e.g., a Server 2012 KB reachable from a Win11
 	// chain), causing the KB criterion to match cross-product conditions.
-	coveredKBs, err = filterKBIDsByRelease(s, coveredKBs, sr.Release)
-	if err != nil {
-		return nil, errors.Wrap(err, "filter covered KBs by release")
+	var releases []string
+	if sr.Release != "" {
+		releases = []string{sr.Release}
 	}
-	unappliedKBs, err = filterKBIDsByRelease(s, unappliedKBs, sr.Release)
-	if err != nil {
-		return nil, errors.Wrap(err, "filter unapplied KBs by release")
-	}
+	coveredKBs, _ := PartitionKBIDsByReleases(exp.Products, exp.Covered, releases)
+	unappliedKBs, _ := PartitionKBIDsByReleases(exp.Products, exp.Unapplied, releases)
 
 	vcmProducts := slices.Collect(maps.Keys(vcm))
 
@@ -264,23 +249,14 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 	return dm, nil
 }
 
-func classifyKBs(s session.Storage, applied []string, unapplied []string) (coveredKBs, unappliedKBs []string, _ error) {
-	r, err := ExpandKBs(s, applied, unapplied)
-	if err != nil {
-		return nil, nil, err
-	}
-	return r.Covered, r.Unapplied, nil
-}
-
 // ExpandKBs walks Microsoft KB supersession chains starting from the given
 // Applied and Unapplied inputs and returns the full classification result,
 // including per-edge data-source attribution for diagnostic use. The
 // classification logic is identical to what Detect uses internally.
 //
-// Options can restrict which Microsoft data sources contribute supersession
-// edges; see WithExpandDataSources.
-func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...ExpandOption) (*ExpandResult, error) {
-	eo := newExpandOptions(opts)
+// When datasources is non-empty, only edges and products contributed by
+// those Microsoft data sources are considered.
+func ExpandKBs(s session.Storage, applied []string, unapplied []string, datasources []sourceTypes.SourceID) (*ExpandResult, error) {
 	// Prefer unapplied when a KB appears in both lists because:
 	// 1. QueryHistory may record a past successful install (Operation=1, ResultCode=2) even after
 	//    the update was rolled back or never fully applied, causing a false "applied" entry.
@@ -288,10 +264,16 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 	//    sources (e.g. Get-HotFix) may also add them to applied, masking the pending reboot state.
 	appliedSet := make(map[string]struct{}, len(applied))
 	for _, kb := range applied {
+		if kb == "" {
+			continue
+		}
 		appliedSet[kb] = struct{}{}
 	}
 	removedFromApplied := make(map[string]struct{})
 	for _, kb := range unapplied {
+		if kb == "" {
+			continue
+		}
 		if _, ok := appliedSet[kb]; ok {
 			removedFromApplied[kb] = struct{}{}
 		}
@@ -308,14 +290,26 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 	// coverage across data sources.
 	visited := make(map[string]struct{})
 	edges := make(map[string][]ExpandEdge)
+	products := make(map[string]map[string]struct{})
+	type edgeKey struct {
+		from string
+		e    ExpandEdge
+	}
+	seenEdge := make(map[edgeKey]struct{})
 
 	addEdge := func(from string, e ExpandEdge) {
-		for _, existing := range edges[from] {
-			if existing == e {
-				return
-			}
+		k := edgeKey{from: from, e: e}
+		if _, ok := seenEdge[k]; ok {
+			return
 		}
+		seenEdge[k] = struct{}{}
 		edges[from] = append(edges[from], e)
+	}
+	addProduct := func(kbid, product string) {
+		if products[kbid] == nil {
+			products[kbid] = make(map[string]struct{})
+		}
+		products[kbid][product] = struct{}{}
 	}
 
 	var walk func(kbid string) error
@@ -332,10 +326,19 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 			}
 			return errors.Wrapf(err, "get microsoft kb %s", kbid)
 		}
+		// Mark this KB as known to the DB even if no allowed-source product
+		// follows, so PartitionKBIDsByReleases can distinguish "absent → keep"
+		// from "present but no allowed-source product → drop".
+		if products[kbid] == nil {
+			products[kbid] = make(map[string]struct{})
+		}
 
 		for srcID, kb := range m {
-			if !eo.allowSource(srcID) {
+			if !allowMicrosoftKBSource(datasources, srcID) {
 				continue
+			}
+			for _, p := range kb.Products {
+				addProduct(kbid, p)
 			}
 			// Forward direction: this KB is superseded by newer KBs.
 			for _, sup := range kb.SupersededBy {
@@ -388,26 +391,35 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 	}
 
 	for _, kbid := range applied {
+		if kbid == "" {
+			continue
+		}
 		if err := walk(kbid); err != nil {
 			return nil, errors.Wrapf(err, "walk supersession chain from applied KB: %s", kbid)
 		}
 	}
 	for _, kbid := range unapplied {
+		if kbid == "" {
+			continue
+		}
 		if err := walk(kbid); err != nil {
 			return nil, errors.Wrapf(err, "walk supersession chain from unapplied KB: %s", kbid)
 		}
 	}
 
 	// Build the reverse adjacency (superseding → list of superseded) used
-	// by the coverage BFS, deduped on the (from, to) pair.
+	// by the coverage BFS. addEdge dedupes by (from, edge), but multiple
+	// edges between the same (from, to) pair (e.g. different sources or
+	// KB-level vs Update-level) collapse to a single revAdj entry.
 	revAdj := make(map[string][]string)
+	revAdjSeen := make(map[[2]string]struct{})
 	for from, es := range edges {
-		seen := make(map[string]struct{}, len(es))
 		for _, e := range es {
-			if _, ok := seen[e.To]; ok {
+			k := [2]string{e.To, from}
+			if _, ok := revAdjSeen[k]; ok {
 				continue
 			}
-			seen[e.To] = struct{}{}
+			revAdjSeen[k] = struct{}{}
 			revAdj[e.To] = append(revAdj[e.To], from)
 		}
 	}
@@ -436,7 +448,7 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 	//   - not covered by any applied superseding KB, or
 	//   - removed from appliedSet by unapplied-preference (always treated as
 	//     unapplied regardless of coverage, to honour the scanner's signal).
-	var coveredKBs, unappliedKBs []string
+	var unappliedKBs []string
 	for kbid := range visited {
 		if _, ok := covered[kbid]; ok {
 			if _, ok := removedFromApplied[kbid]; !ok {
@@ -446,30 +458,21 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 		unappliedKBs = append(unappliedKBs, kbid)
 	}
 
-	for kbid := range covered {
-		coveredKBs = append(coveredKBs, kbid)
-	}
+	coveredKBs := slices.Collect(maps.Keys(covered))
 
-	visitedKBs := make([]string, 0, len(visited))
-	for kbid := range visited {
-		visitedKBs = append(visitedKBs, kbid)
-	}
-	slices.Sort(visitedKBs)
-	slices.Sort(coveredKBs)
-	slices.Sort(unappliedKBs)
+	conflicts := slices.Collect(maps.Keys(removedFromApplied))
 
-	conflicts := make([]string, 0, len(removedFromApplied))
-	for kbid := range removedFromApplied {
-		conflicts = append(conflicts, kbid)
+	productsList := make(map[string][]string, len(products))
+	for kbid, ps := range products {
+		productsList[kbid] = slices.Collect(maps.Keys(ps))
 	}
-	slices.Sort(conflicts)
 
 	return &ExpandResult{
 		Inputs:    ExpandInputs{Applied: applied, Unapplied: unapplied},
 		Covered:   coveredKBs,
 		Unapplied: unappliedKBs,
-		Visited:   visitedKBs,
 		Edges:     edges,
+		Products:  productsList,
 		Conflicts: conflicts,
 	}, nil
 }
@@ -481,12 +484,12 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...
 // applied represent platforms host should-but-hasn't applied yet, and need
 // to be in vcm so KB criteria targeting those products can be evaluated.
 //
-// This is intentionally narrower than classifyKBs's bidirectional walk:
-// the backward Supersedes chain is excluded because following it from
-// applied or unapplied input pulls in old historical KBs (e.g. KB279328
-// for Internet Explorer 5.01 from 2001) whose products would otherwise
-// leak cross-era bulletins (MS01-MS09 Internet Explorer entries) into
-// modern hosts via the isKBCriterionApp allowlist.
+// This is intentionally narrower than ExpandKBs's bidirectional walk: the
+// backward Supersedes chain is excluded because following it from applied
+// or unapplied input pulls in old historical KBs (e.g. KB279328 for
+// Internet Explorer 5.01 from 2001) whose products would otherwise leak
+// cross-era bulletins (MS01-MS09 Internet Explorer entries) into modern
+// hosts via the isKBCriterionApp allowlist.
 func forwardSupersedersFromApplied(s session.Storage, applied []string) ([]string, error) {
 	// Seed visited and queue from a deduplicated, non-empty applied list so
 	// each starting KB is fetched at most once and downstream BFS treats
@@ -548,66 +551,42 @@ func forwardSupersedersFromApplied(s session.Storage, applied []string) ([]strin
 	return out, nil
 }
 
-// filterKBIDsByRelease removes KBs whose products are all irrelevant to
-// the given release. When release is empty, all KBs pass through unchanged.
-// KBs not found in the DB are kept to avoid false negatives.
-func filterKBIDsByRelease(s session.Storage, kbs []string, release string) ([]string, error) {
-	var releases []string
-	if release != "" {
-		releases = []string{release}
-	}
-	kept, _, err := PartitionKBIDsByReleases(s, kbs, releases)
-	return kept, err
-}
-
-// PartitionKBIDsByReleases splits kbs into those whose products are relevant
-// to any of the given releases (kept) and those whose products are unrelated
-// to all of them (dropped). When releases is empty, all KBs are kept. KBs
-// not found in the database are kept (to avoid false negatives) and are not
-// reported in dropped.
+// PartitionKBIDsByReleases splits kbs into those whose products (as cached
+// in products by ExpandKBs in ExpandResult.Products) overlap any of the
+// given releases (kept) and those whose products are unrelated to all of
+// them (dropped). When releases is empty, all KBs are kept. KBs absent
+// from products (KBs that ExpandKBs did not find in the database) are
+// kept to avoid false negatives, and are not reported in dropped.
 //
-// Options can restrict the data sources whose products are considered when
-// evaluating relevance; see WithExpandDataSources.
-func PartitionKBIDsByReleases(s session.Storage, kbs []string, releases []string, opts ...ExpandOption) (kept, dropped []string, _ error) {
+// The data source filter applied at expansion time is automatically
+// respected: ExpandResult.Products only contains products contributed by
+// data sources allowed when ExpandKBs was called.
+func PartitionKBIDsByReleases(products map[string][]string, kbs []string, releases []string) (kept, dropped []string) {
 	if len(releases) == 0 {
-		return kbs, nil, nil
+		return kbs, nil
 	}
-	eo := newExpandOptions(opts)
 
 	kept = make([]string, 0, len(kbs))
 	for _, kbid := range kbs {
-		m, err := s.GetMicrosoftKB(kbid)
-		if err != nil {
-			if errors.Is(err, dbTypes.ErrNotFoundMicrosoftKB) {
-				kept = append(kept, kbid)
-				continue
-			}
-			return nil, nil, errors.Wrapf(err, "get microsoft kb %s", kbid)
+		ps, ok := products[kbid]
+		if !ok {
+			kept = append(kept, kbid)
+			continue
 		}
-		if func() bool {
-			for srcID, kb := range m {
-				if !eo.allowSource(srcID) {
-					continue
-				}
-				if slices.ContainsFunc(kb.Products, func(p string) bool {
-					for _, r := range releases {
-						if filterMicrosoftKBProduct(p, r) {
-							return true
-						}
-					}
-					return false
-				}) {
+		if slices.ContainsFunc(ps, func(p string) bool {
+			for _, r := range releases {
+				if filterMicrosoftKBProduct(p, r) {
 					return true
 				}
 			}
 			return false
-		}() {
+		}) {
 			kept = append(kept, kbid)
 		} else {
 			dropped = append(dropped, kbid)
 		}
 	}
-	return kept, dropped, nil
+	return kept, dropped
 }
 
 func normalizeMicrosoftPackageName(name, release string) []string {

--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -14,12 +14,61 @@ import (
 	kbcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion"
 	vcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
 	dbTypes "github.com/MaineK00n/vuls2/pkg/db/session/types"
 	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 	"github.com/MaineK00n/vuls2/pkg/detect/util"
 	scanTypes "github.com/MaineK00n/vuls2/pkg/scan/types"
 )
+
+// ExpandResult describes how an input set of Applied/Unapplied KBs is
+// expanded through Microsoft KB supersession chains for vulnerability
+// detection. It carries the inputs, the discovered edges (with data-source
+// attribution), and the final classification used by Detect.
+type ExpandResult struct {
+	Inputs    ExpandInputs
+	Covered   []string
+	Unapplied []string
+	Visited   []string
+	// Edges maps a "from" KB ID (the superseded KB) to the list of edges
+	// pointing at superseding KBs, each annotated with the data source and
+	// whether the edge was reported at KB level or per-update level.
+	Edges map[string][]ExpandEdge
+	// Conflicts lists KBs that appeared in both the Applied and Unapplied
+	// inputs. Per the classifier policy, conflicts are treated as Unapplied.
+	Conflicts []string
+}
+
+type ExpandInputs struct {
+	Applied   []string
+	Unapplied []string
+}
+
+type ExpandEdgeLevel int
+
+const (
+	ExpandEdgeLevelKB ExpandEdgeLevel = iota
+	ExpandEdgeLevelUpdate
+)
+
+func (l ExpandEdgeLevel) String() string {
+	switch l {
+	case ExpandEdgeLevelKB:
+		return "KB-level"
+	case ExpandEdgeLevelUpdate:
+		return "Update-level"
+	default:
+		return "unknown"
+	}
+}
+
+type ExpandEdge struct {
+	To       string
+	Source   sourceTypes.SourceID
+	Level    ExpandEdgeLevel
+	UpdateID string
+}
 
 func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.ScanResult, concurrency int) (map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, error) {
 	// Collect product names as index keys from installed packages and KB data.
@@ -184,6 +233,18 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 }
 
 func classifyKBs(s session.Storage, applied []string, unapplied []string) (coveredKBs, unappliedKBs []string, _ error) {
+	r, err := ExpandKBs(s, applied, unapplied)
+	if err != nil {
+		return nil, nil, err
+	}
+	return r.Covered, r.Unapplied, nil
+}
+
+// ExpandKBs walks Microsoft KB supersession chains starting from the given
+// Applied and Unapplied inputs and returns the full classification result,
+// including per-edge data-source attribution for diagnostic use. The
+// classification logic is identical to what Detect uses internally.
+func ExpandKBs(s session.Storage, applied []string, unapplied []string) (*ExpandResult, error) {
 	// Prefer unapplied when a KB appears in both lists because:
 	// 1. QueryHistory may record a past successful install (Operation=1, ResultCode=2) even after
 	//    the update was rolled back or never fully applied, causing a false "applied" entry.
@@ -201,16 +262,25 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 		delete(appliedSet, kb)
 	}
 
-	// Collect all reachable KBs by traversing SupersededBy chains forward
-	// and Supersedes chains backward from both Applied and Unapplied, and
-	// build a reverse edge map (superseding KB → list of superseded KBs) for
-	// the coverage BFS. Walking both directions makes the graph discovery
-	// robust against incomplete SupersededBy data: even if old→new links are
-	// missing, new→old Supersedes links can bridge the gap. Edges are sourced
-	// from both KB-level fields (e.g. CVRF) and per-Update fields (e.g. MSUC,
-	// wsusscn2) to maximize coverage across data sources.
+	// build a forward edge map keyed by the superseded KB ID (so the same
+	// edge can be inspected later, with its data-source attribution
+	// preserved, by the kb-expand command). Walking both directions makes
+	// the graph discovery robust against incomplete SupersededBy data:
+	// even if old→new links are missing, new→old Supersedes links can
+	// bridge the gap. Edges are sourced from both KB-level fields (e.g.
+	// CVRF) and per-Update fields (e.g. MSUC, wsusscn2) to maximize
+	// coverage across data sources.
 	visited := make(map[string]struct{})
-	revEdges := make(map[string][]string)
+	edges := make(map[string][]ExpandEdge)
+
+	addEdge := func(from string, e ExpandEdge) {
+		for _, existing := range edges[from] {
+			if existing == e {
+				return
+			}
+		}
+		edges[from] = append(edges[from], e)
+	}
 
 	var walk func(kbid string) error
 	walk = func(kbid string) error {
@@ -227,13 +297,13 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 			return errors.Wrapf(err, "get microsoft kb %s", kbid)
 		}
 
-		for _, kb := range m {
+		for srcID, kb := range m {
 			// Forward direction: this KB is superseded by newer KBs.
 			for _, sup := range kb.SupersededBy {
 				if sup.KBID == "" {
 					continue
 				}
-				revEdges[sup.KBID] = append(revEdges[sup.KBID], kbid)
+				addEdge(kbid, ExpandEdge{To: sup.KBID, Source: srcID, Level: ExpandEdgeLevelKB})
 				if err := walk(sup.KBID); err != nil {
 					return errors.Wrapf(err, "walk supersession from KB %s to %s", kbid, sup.KBID)
 				}
@@ -243,19 +313,21 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 					if sup.KBID == "" {
 						continue
 					}
-					revEdges[sup.KBID] = append(revEdges[sup.KBID], kbid)
+					addEdge(kbid, ExpandEdge{To: sup.KBID, Source: srcID, Level: ExpandEdgeLevelUpdate, UpdateID: u.UpdateID})
 					if err := walk(sup.KBID); err != nil {
 						return errors.Wrapf(err, "walk supersession from KB %s to %s (via update)", kbid, sup.KBID)
 					}
 				}
 			}
 
-			// Backward direction: this KB supersedes older KBs.
+			// Backward direction: this KB supersedes older KBs. Flip the
+			// edge direction to match our forward-keyed edges map (keyed
+			// by superseded KB ID).
 			for _, sub := range kb.Supersedes {
 				if sub.KBID == "" {
 					continue
 				}
-				revEdges[kbid] = append(revEdges[kbid], sub.KBID)
+				addEdge(sub.KBID, ExpandEdge{To: kbid, Source: srcID, Level: ExpandEdgeLevelKB})
 				if err := walk(sub.KBID); err != nil {
 					return errors.Wrapf(err, "walk supersedes from KB %s to %s", kbid, sub.KBID)
 				}
@@ -265,7 +337,7 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 					if sub.KBID == "" {
 						continue
 					}
-					revEdges[kbid] = append(revEdges[kbid], sub.KBID)
+					addEdge(sub.KBID, ExpandEdge{To: kbid, Source: srcID, Level: ExpandEdgeLevelUpdate, UpdateID: u.UpdateID})
 					if err := walk(sub.KBID); err != nil {
 						return errors.Wrapf(err, "walk supersedes from KB %s to %s (via update)", kbid, sub.KBID)
 					}
@@ -278,12 +350,26 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 
 	for _, kbid := range applied {
 		if err := walk(kbid); err != nil {
-			return nil, nil, errors.Wrapf(err, "walk supersession chain from applied KB: %s", kbid)
+			return nil, errors.Wrapf(err, "walk supersession chain from applied KB: %s", kbid)
 		}
 	}
 	for _, kbid := range unapplied {
 		if err := walk(kbid); err != nil {
-			return nil, nil, errors.Wrapf(err, "walk supersession chain from unapplied KB: %s", kbid)
+			return nil, errors.Wrapf(err, "walk supersession chain from unapplied KB: %s", kbid)
+		}
+	}
+
+	// Build the reverse adjacency (superseding → list of superseded) used
+	// by the coverage BFS, deduped on the (from, to) pair.
+	revAdj := make(map[string][]string)
+	for from, es := range edges {
+		seen := make(map[string]struct{}, len(es))
+		for _, e := range es {
+			if _, ok := seen[e.To]; ok {
+				continue
+			}
+			seen[e.To] = struct{}{}
+			revAdj[e.To] = append(revAdj[e.To], from)
 		}
 	}
 
@@ -299,7 +385,7 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 	}
 	for head := 0; head < len(queue); head++ {
 		cur := queue[head]
-		for _, pred := range revEdges[cur] {
+		for _, pred := range revAdj[cur] {
 			if _, ok := covered[pred]; !ok {
 				covered[pred] = struct{}{}
 				queue = append(queue, pred)
@@ -311,6 +397,7 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 	//   - not covered by any applied superseding KB, or
 	//   - removed from appliedSet by unapplied-preference (always treated as
 	//     unapplied regardless of coverage, to honour the scanner's signal).
+	var coveredKBs, unappliedKBs []string
 	for kbid := range visited {
 		if _, ok := covered[kbid]; ok {
 			if _, ok := removedFromApplied[kbid]; !ok {
@@ -324,7 +411,28 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 		coveredKBs = append(coveredKBs, kbid)
 	}
 
-	return coveredKBs, unappliedKBs, nil
+	visitedKBs := make([]string, 0, len(visited))
+	for kbid := range visited {
+		visitedKBs = append(visitedKBs, kbid)
+	}
+	slices.Sort(visitedKBs)
+	slices.Sort(coveredKBs)
+	slices.Sort(unappliedKBs)
+
+	conflicts := make([]string, 0, len(removedFromApplied))
+	for kbid := range removedFromApplied {
+		conflicts = append(conflicts, kbid)
+	}
+	slices.Sort(conflicts)
+
+	return &ExpandResult{
+		Inputs:    ExpandInputs{Applied: applied, Unapplied: unapplied},
+		Covered:   coveredKBs,
+		Unapplied: unappliedKBs,
+		Visited:   visitedKBs,
+		Edges:     edges,
+		Conflicts: conflicts,
+	}, nil
 }
 
 // forwardSupersedersFromApplied returns the KBs reachable from applied via
@@ -405,19 +513,28 @@ func forwardSupersedersFromApplied(s session.Storage, applied []string) ([]strin
 // the given release. When release is empty, all KBs pass through unchanged.
 // KBs not found in the DB are kept to avoid false negatives.
 func filterKBIDsByRelease(s session.Storage, kbs []string, release string) ([]string, error) {
+	kept, _, err := PartitionKBIDsByRelease(s, kbs, release)
+	return kept, err
+}
+
+// PartitionKBIDsByRelease splits kbs into those whose products are relevant
+// to the release (kept) and those whose products are all unrelated (dropped).
+// When release is empty, all KBs are kept. KBs not found in the database are
+// kept (to avoid false negatives) and are not reported in dropped.
+func PartitionKBIDsByRelease(s session.Storage, kbs []string, release string) (kept, dropped []string, _ error) {
 	if release == "" {
-		return kbs, nil
+		return kbs, nil, nil
 	}
 
-	filtered := make([]string, 0, len(kbs))
+	kept = make([]string, 0, len(kbs))
 	for _, kbid := range kbs {
 		m, err := s.GetMicrosoftKB(kbid)
 		if err != nil {
 			if errors.Is(err, dbTypes.ErrNotFoundMicrosoftKB) {
-				filtered = append(filtered, kbid)
+				kept = append(kept, kbid)
 				continue
 			}
-			return nil, errors.Wrapf(err, "get microsoft kb %s", kbid)
+			return nil, nil, errors.Wrapf(err, "get microsoft kb %s", kbid)
 		}
 		if func() bool {
 			for _, kb := range m {
@@ -429,10 +546,12 @@ func filterKBIDsByRelease(s session.Storage, kbs []string, release string) ([]st
 			}
 			return false
 		}() {
-			filtered = append(filtered, kbid)
+			kept = append(kept, kbid)
+		} else {
+			dropped = append(dropped, kbid)
 		}
 	}
-	return filtered, nil
+	return kept, dropped, nil
 }
 
 func normalizeMicrosoftPackageName(name, release string) []string {

--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -70,6 +70,38 @@ type ExpandEdge struct {
 	UpdateID string
 }
 
+// ExpandOption configures KB-expansion helpers (ExpandKBs and
+// PartitionKBIDsByReleases). Options are additive; the zero set of options
+// matches the behaviour Detect uses.
+type ExpandOption func(*expandOptions)
+
+type expandOptions struct {
+	datasources []sourceTypes.SourceID
+}
+
+// WithExpandDataSources restricts KB-expansion (supersession walking and
+// product evaluation) to the given Microsoft data sources. When the list is
+// empty, all sources are considered. Edges and products contributed by a
+// source not in the list are ignored.
+func WithExpandDataSources(ds []sourceTypes.SourceID) ExpandOption {
+	return func(o *expandOptions) { o.datasources = ds }
+}
+
+func newExpandOptions(opts []ExpandOption) *expandOptions {
+	eo := &expandOptions{}
+	for _, o := range opts {
+		o(eo)
+	}
+	return eo
+}
+
+func (o *expandOptions) allowSource(id sourceTypes.SourceID) bool {
+	if len(o.datasources) == 0 {
+		return true
+	}
+	return slices.Contains(o.datasources, id)
+}
+
 func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.ScanResult, concurrency int) (map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, error) {
 	// Collect product names as index keys from installed packages and KB data.
 	vcm := make(map[string][]int)
@@ -244,7 +276,11 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 // Applied and Unapplied inputs and returns the full classification result,
 // including per-edge data-source attribution for diagnostic use. The
 // classification logic is identical to what Detect uses internally.
-func ExpandKBs(s session.Storage, applied []string, unapplied []string) (*ExpandResult, error) {
+//
+// Options can restrict which Microsoft data sources contribute supersession
+// edges; see WithExpandDataSources.
+func ExpandKBs(s session.Storage, applied []string, unapplied []string, opts ...ExpandOption) (*ExpandResult, error) {
+	eo := newExpandOptions(opts)
 	// Prefer unapplied when a KB appears in both lists because:
 	// 1. QueryHistory may record a past successful install (Operation=1, ResultCode=2) even after
 	//    the update was rolled back or never fully applied, causing a false "applied" entry.
@@ -298,6 +334,9 @@ func ExpandKBs(s session.Storage, applied []string, unapplied []string) (*Expand
 		}
 
 		for srcID, kb := range m {
+			if !eo.allowSource(srcID) {
+				continue
+			}
 			// Forward direction: this KB is superseded by newer KBs.
 			for _, sup := range kb.SupersededBy {
 				if sup.KBID == "" {
@@ -513,18 +552,27 @@ func forwardSupersedersFromApplied(s session.Storage, applied []string) ([]strin
 // the given release. When release is empty, all KBs pass through unchanged.
 // KBs not found in the DB are kept to avoid false negatives.
 func filterKBIDsByRelease(s session.Storage, kbs []string, release string) ([]string, error) {
-	kept, _, err := PartitionKBIDsByRelease(s, kbs, release)
+	var releases []string
+	if release != "" {
+		releases = []string{release}
+	}
+	kept, _, err := PartitionKBIDsByReleases(s, kbs, releases)
 	return kept, err
 }
 
-// PartitionKBIDsByRelease splits kbs into those whose products are relevant
-// to the release (kept) and those whose products are all unrelated (dropped).
-// When release is empty, all KBs are kept. KBs not found in the database are
-// kept (to avoid false negatives) and are not reported in dropped.
-func PartitionKBIDsByRelease(s session.Storage, kbs []string, release string) (kept, dropped []string, _ error) {
-	if release == "" {
+// PartitionKBIDsByReleases splits kbs into those whose products are relevant
+// to any of the given releases (kept) and those whose products are unrelated
+// to all of them (dropped). When releases is empty, all KBs are kept. KBs
+// not found in the database are kept (to avoid false negatives) and are not
+// reported in dropped.
+//
+// Options can restrict the data sources whose products are considered when
+// evaluating relevance; see WithExpandDataSources.
+func PartitionKBIDsByReleases(s session.Storage, kbs []string, releases []string, opts ...ExpandOption) (kept, dropped []string, _ error) {
+	if len(releases) == 0 {
 		return kbs, nil, nil
 	}
+	eo := newExpandOptions(opts)
 
 	kept = make([]string, 0, len(kbs))
 	for _, kbid := range kbs {
@@ -537,9 +585,17 @@ func PartitionKBIDsByRelease(s session.Storage, kbs []string, release string) (k
 			return nil, nil, errors.Wrapf(err, "get microsoft kb %s", kbid)
 		}
 		if func() bool {
-			for _, kb := range m {
+			for srcID, kb := range m {
+				if !eo.allowSource(srcID) {
+					continue
+				}
 				if slices.ContainsFunc(kb.Products, func(p string) bool {
-					return filterMicrosoftKBProduct(p, release)
+					for _, r := range releases {
+						if filterMicrosoftKBProduct(p, r) {
+							return true
+						}
+					}
+					return false
 				}) {
 					return true
 				}

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -1657,3 +1657,222 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 		})
 	}
 }
+
+func TestExpandKBs_DataSourceFilter(t *testing.T) {
+	type args struct {
+		applied     []string
+		unapplied   []string
+		datasources []sourceTypes.SourceID
+	}
+	tests := []struct {
+		name          string
+		fixture       string
+		config        session.Config
+		args          args
+		wantCovered   []string
+		wantUnapplied []string
+	}{
+		{
+			name:    "no filter walks every source's chain",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied: []string{"4012606"},
+			},
+			wantCovered:   []string{"4012606"},
+			wantUnapplied: []string{"4013429"},
+		},
+		{
+			name:    "filtering to a source that doesn't know the input KB stops the walk",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:     []string{"4012606"},
+				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
+			},
+			wantCovered:   []string{"4012606"},
+			wantUnapplied: nil,
+		},
+		{
+			name:    "filtering to the source that owns the chain preserves it",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:     []string{"5000802"},
+				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
+			},
+			wantCovered:   []string{"5000802"},
+			wantUnapplied: []string{"5001330", "5003173", "5003637"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
+				t.Fatalf("populate db. error = %v", err)
+			}
+
+			s, err := tt.config.New()
+			if err != nil {
+				t.Fatalf("new session. error = %v", err)
+			}
+
+			if err := s.Storage().Open(); err != nil {
+				t.Fatalf("open db connection. error = %v", err)
+			}
+			defer s.Storage().Close()
+
+			var opts []microsoft.ExpandOption
+			if len(tt.args.datasources) > 0 {
+				opts = append(opts, microsoft.WithExpandDataSources(tt.args.datasources))
+			}
+			got, err := microsoft.ExpandKBs(s.Storage(), tt.args.applied, tt.args.unapplied, opts...)
+			if err != nil {
+				t.Fatalf("ExpandKBs() unexpected error: %v", err)
+			}
+
+			less := func(a, b string) bool { return a < b }
+			if diff := cmp.Diff(tt.wantCovered, got.Covered, cmpopts.SortSlices(less)); diff != "" {
+				t.Errorf("ExpandKBs() covered (-expected +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantUnapplied, got.Unapplied, cmpopts.SortSlices(less)); diff != "" {
+				t.Errorf("ExpandKBs() unapplied (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
+	type args struct {
+		kbs      []string
+		releases []string
+	}
+	tests := []struct {
+		name        string
+		fixture     string
+		config      session.Config
+		args        args
+		wantKept    []string
+		wantDropped []string
+	}{
+		{
+			name:    "empty releases keeps everything",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs:      []string{"9000001", "9000002"},
+				releases: nil,
+			},
+			wantKept:    []string{"9000001", "9000002"},
+			wantDropped: nil,
+		},
+		{
+			name:    "single release matches both KBs",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs:      []string{"9000001", "9000002"},
+				releases: []string{"Windows 10 Version 21H2 for x64-based Systems"},
+			},
+			wantKept:    []string{"9000001", "9000002"},
+			wantDropped: nil,
+		},
+		{
+			name:    "single release matches only one KB",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs:      []string{"9000001", "9000002"},
+				releases: []string{"Windows Server 2012 R2"},
+			},
+			wantKept:    []string{"9000001"},
+			wantDropped: []string{"9000002"},
+		},
+		{
+			name:    "two releases keep both KBs via union semantics",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs: []string{"9000001", "9000002"},
+				releases: []string{
+					"Windows Server 2012 R2",
+					"Windows 10 Version 21H2 for ARM64-based Systems",
+				},
+			},
+			wantKept:    []string{"9000001", "9000002"},
+			wantDropped: nil,
+		},
+		{
+			name:    "release that matches none drops everything",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs:      []string{"9000001", "9000002"},
+				releases: []string{"Windows 11 Version 23H2 for x64-based Systems"},
+			},
+			wantKept:    []string{},
+			wantDropped: []string{"9000001", "9000002"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
+				t.Fatalf("populate db. error = %v", err)
+			}
+
+			s, err := tt.config.New()
+			if err != nil {
+				t.Fatalf("new session. error = %v", err)
+			}
+
+			if err := s.Storage().Open(); err != nil {
+				t.Fatalf("open db connection. error = %v", err)
+			}
+			defer s.Storage().Close()
+
+			gotKept, gotDropped, err := microsoft.PartitionKBIDsByReleases(s.Storage(), tt.args.kbs, tt.args.releases)
+			if err != nil {
+				t.Fatalf("PartitionKBIDsByReleases() unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.wantKept, gotKept); diff != "" {
+				t.Errorf("PartitionKBIDsByReleases() kept (-expected +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tt.wantDropped, gotDropped); diff != "" {
+				t.Errorf("PartitionKBIDsByReleases() dropped (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -578,20 +578,18 @@ func TestDetect(t *testing.T) {
 	}
 }
 
-func Test_classifyKBs(t *testing.T) {
+func TestExpandKBs(t *testing.T) {
 	type args struct {
-		_         session.Storage
-		applied   []string
-		unapplied []string
+		applied     []string
+		unapplied   []string
+		datasources []sourceTypes.SourceID
 	}
 	tests := []struct {
-		name        string
-		fixture     string
-		config      session.Config
-		args        args
-		wantCovered   []string
-		wantUnapplied []string
-		wantErr       error
+		name    string
+		fixture string
+		config  session.Config
+		args    args
+		want    microsoft.ExpandResult
 	}{
 		{
 			name:    "no input",
@@ -605,8 +603,56 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   nil,
 				unapplied: nil,
 			},
-			wantCovered:   nil,
-			wantUnapplied: nil,
+			want: microsoft.ExpandResult{
+				Edges:    map[string][]microsoft.ExpandEdge{},
+				Products: map[string][]string{},
+			},
+		},
+		{
+			// Empty KB IDs must be skipped at every entry point (appliedSet
+			// seeding, unapplied conflict handling, and the walk loops) so
+			// they cannot leak into visited / Covered / Unapplied. The raw
+			// input slices are still echoed verbatim in Inputs.
+			name:    "empty KB IDs in input are skipped",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:   []string{"", "5000802"},
+				unapplied: []string{""},
+			},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"", "5000802"}, Unapplied: []string{""}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330", "5003173", "5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "applied only, discover unapplied via supersession",
@@ -619,8 +665,38 @@ func Test_classifyKBs(t *testing.T) {
 			args: args{
 				applied: []string{"5000802"},
 			},
-			wantCovered:   []string{"5000802"},
-			wantUnapplied: []string{"5001330", "5003173", "5003637"},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330", "5003173", "5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				// 5003637 is referenced by 5003173.SupersededBy but is not
+				// in the fixture, so it appears in Unapplied but is absent
+				// from Products.
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "unapplied with chain",
@@ -634,8 +710,34 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   []string{},
 				unapplied: []string{"5000802"},
 			},
-			wantCovered:   nil,
-			wantUnapplied: []string{"5000802", "5001330", "5003173", "5003637"},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{}, Unapplied: []string{"5000802"}},
+				Unapplied: []string{"5000802", "5001330", "5003173", "5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "latest superseding KB not applied remains unapplied",
@@ -648,8 +750,35 @@ func Test_classifyKBs(t *testing.T) {
 			args: args{
 				applied: []string{"5000802", "5001330", "5003173"},
 			},
-			wantCovered:   []string{"5000802", "5001330", "5003173"},
-			wantUnapplied: []string{"5003637"},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802", "5001330", "5003173"}},
+				Covered:   []string{"5000802", "5001330", "5003173"},
+				Unapplied: []string{"5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "intermediate KB covered by applied superseding KB",
@@ -662,8 +791,35 @@ func Test_classifyKBs(t *testing.T) {
 			args: args{
 				applied: []string{"5000802", "5003173"},
 			},
-			wantCovered:   []string{"5000802", "5001330", "5003173"},
-			wantUnapplied: []string{"5003637"},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802", "5003173"}},
+				Covered:   []string{"5000802", "5001330", "5003173"},
+				Unapplied: []string{"5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "KB in both applied and unapplied prefers unapplied",
@@ -677,8 +833,36 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   []string{"5000802", "5001330"},
 				unapplied: []string{"5000802"},
 			},
-			wantCovered:   []string{"5000802", "5001330"},
-			wantUnapplied: []string{"5000802", "5003173", "5003637"},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802", "5001330"}, Unapplied: []string{"5000802"}},
+				Covered:   []string{"5000802", "5001330"},
+				Unapplied: []string{"5000802", "5003173", "5003637"},
+				Conflicts: []string{"5000802"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "supersedes bridges gap in superseded_by chain",
@@ -692,8 +876,21 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   []string{"7000004"},
 				unapplied: []string{"7000001"},
 			},
-			wantCovered:   []string{"7000001", "7000002", "7000003", "7000004"},
-			wantUnapplied: nil,
+			want: microsoft.ExpandResult{
+				Inputs:  microsoft.ExpandInputs{Applied: []string{"7000004"}, Unapplied: []string{"7000001"}},
+				Covered: []string{"7000001", "7000002", "7000003", "7000004"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"7000001": {{To: "7000002", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"7000002": {{To: "7000003", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"7000003": {{To: "7000004", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"7000001": {"Windows 10 Version 2004 for x64-based Systems"},
+					"7000002": {"Windows 10 Version 2004 for x64-based Systems"},
+					"7000003": {"Windows 10 Version 2004 for x64-based Systems"},
+					"7000004": {"Windows 10 Version 2004 for x64-based Systems"},
+				},
+			},
 		},
 		{
 			name:    "superseded_by chain to applied KB covers all without supersedes field",
@@ -707,8 +904,131 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   []string{"5003637"},
 				unapplied: []string{"5000802"},
 			},
-			wantCovered:   []string{"5000802", "5001330", "5003173", "5003637"},
-			wantUnapplied: nil,
+			want: microsoft.ExpandResult{
+				Inputs:  microsoft.ExpandInputs{Applied: []string{"5003637"}, Unapplied: []string{"5000802"}},
+				Covered: []string{"5000802", "5001330", "5003173", "5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
+		},
+		{
+			name:    "no datasource filter walks every source's chain",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied: []string{"4012606"},
+			},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"4012606"}},
+				Covered:   []string{"4012606"},
+				Unapplied: []string{"4013429"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"4012606": {{To: "4013429", Source: "microsoft-bulletin", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"4012606": {
+						"Internet Explorer 11 on Windows 10 for x64-based Systems",
+						"Microsoft Edge on Windows 10 for x64-based Systems",
+						"Microsoft XML Core Services 3.0 on Windows 10 for x64-based Systems",
+						"Windows 10 for x64-based Systems",
+					},
+					"4013429": {
+						"Windows 10 for x64-based Systems",
+					},
+				},
+			},
+		},
+		{
+			name:    "datasource filter excluding the input KB's source stops the walk",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:     []string{"4012606"},
+				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
+			},
+			want: microsoft.ExpandResult{
+				Inputs:  microsoft.ExpandInputs{Applied: []string{"4012606"}},
+				Covered: []string{"4012606"},
+				Edges:   map[string][]microsoft.ExpandEdge{},
+				// 4012606 is in DB (microsoft-bulletin only) so it gets a
+				// Products entry, but no allowed-source product follows the
+				// datasource filter, so the slice is empty.
+				Products: map[string][]string{
+					"4012606": nil,
+				},
+			},
+		},
+		{
+			name:    "datasource filter matching the chain's source preserves it",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:     []string{"5000802"},
+				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
+			},
+			want: microsoft.ExpandResult{
+				Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+				Covered:   []string{"5000802"},
+				Unapplied: []string{"5001330", "5003173", "5003637"},
+				Edges: map[string][]microsoft.ExpandEdge{
+					"5000802": {{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5001330": {{To: "5003173", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+					"5003173": {{To: "5003637", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB}},
+				},
+				Products: map[string][]string{
+					"5000802": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Internet Explorer 11 on Windows 10 Version 20H2 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 2004 for x64-based Systems",
+						"Microsoft Edge (EdgeHTML-based) on Windows 10 Version 20H2 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5001330": {
+						"Internet Explorer 11 on Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+					"5003173": {
+						"Windows 10 Version 2004 for x64-based Systems",
+						"Windows 10 Version 20H2 for x64-based Systems",
+					},
+				},
+			},
 		},
 		{
 			name:    "per-update supersedes (MSUC) covers chain",
@@ -722,8 +1042,24 @@ func Test_classifyKBs(t *testing.T) {
 				applied:   []string{"8000003"},
 				unapplied: nil,
 			},
-			wantCovered:   []string{"8000001", "8000002", "8000003"},
-			wantUnapplied: nil,
+			want: microsoft.ExpandResult{
+				Inputs:  microsoft.ExpandInputs{Applied: []string{"8000003"}},
+				Covered: []string{"8000001", "8000002", "8000003"},
+				// 8000001/8000002/8000003 are connected via per-Update
+				// Supersedes chains in microsoft-msuc only.
+				Edges: map[string][]microsoft.ExpandEdge{
+					"8000001": {{To: "8000002", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "00000000-0000-0000-0000-000000008002"}},
+					"8000002": {{To: "8000003", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "00000000-0000-0000-0000-000000008003"}},
+				},
+				// Top-level kb.Products is empty for these fixtures (only
+				// per-update products are set), so the entries are present
+				// (KBs are in DB) but with empty product lists.
+				Products: map[string][]string{
+					"8000001": nil,
+					"8000002": nil,
+					"8000003": nil,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -742,23 +1078,27 @@ func Test_classifyKBs(t *testing.T) {
 			}
 			defer s.Storage().Close()
 
-			gotCovered, gotUnapplied, err := microsoft.ClassifyKBs(s.Storage(), tt.args.applied, tt.args.unapplied)
-			switch {
-			case tt.wantErr == nil && err != nil:
-				t.Errorf("classifyKBs() unexpected error: %v", err)
-			case tt.wantErr != nil && err == nil:
-				t.Errorf("classifyKBs() expected error has not occurred")
-			case tt.wantErr != nil && err != nil:
-				if tt.wantErr.Error() != err.Error() {
-					t.Errorf("classifyKBs() error mismatch: want %v, got %v", tt.wantErr, err)
-				}
-			default:
-				if diff := cmp.Diff(tt.wantCovered, gotCovered, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
-					t.Errorf("classifyKBs() covered (-expected +got):\n%s", diff)
-				}
-				if diff := cmp.Diff(tt.wantUnapplied, gotUnapplied, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
-					t.Errorf("classifyKBs() unapplied (-expected +got):\n%s", diff)
-				}
+			got, err := microsoft.ExpandKBs(s.Storage(), tt.args.applied, tt.args.unapplied, tt.args.datasources)
+			if err != nil {
+				t.Fatalf("ExpandKBs() unexpected error: %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, *got,
+				cmpopts.SortSlices(func(a, b string) bool { return a < b }),
+				cmpopts.SortSlices(func(a, b microsoft.ExpandEdge) bool {
+					if a.To != b.To {
+						return a.To < b.To
+					}
+					if a.Source != b.Source {
+						return a.Source < b.Source
+					}
+					if a.Level != b.Level {
+						return a.Level < b.Level
+					}
+					return a.UpdateID < b.UpdateID
+				}),
+			); diff != "" {
+				t.Errorf("ExpandKBs() (-expected +got):\n%s", diff)
 			}
 		})
 	}
@@ -887,153 +1227,6 @@ func Test_forwardSupersedersFromApplied(t *testing.T) {
 			default:
 				if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
 					t.Errorf("forwardSupersedersFromApplied() (-expected +got):\n%s", diff)
-				}
-			}
-		})
-	}
-}
-
-func Test_filterKBIDsByRelease(t *testing.T) {
-	type args struct {
-		kbs     []string
-		release string
-	}
-	tests := []struct {
-		name    string
-		fixture string
-		config  session.Config
-		args    args
-		want    []string
-		wantErr error
-	}{
-		{
-			name:    "no input",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     nil,
-				release: "Windows 10 Version 21H2 for x64-based Systems",
-			},
-			want: []string{},
-		},
-		{
-			name:    "filters out cross-product KB for different release",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9000001", "9000002"},
-				release: "Windows Server 2012 R2",
-			},
-			want: []string{"9000001"},
-		},
-		{
-			name:    "keeps KB matching host release",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9000001", "9000002"},
-				release: "Windows 10 Version 21H2 for x64-based Systems",
-			},
-			want: []string{"9000001", "9000002"},
-		},
-		{
-			name:    "KB not found in DB is kept",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9999999", "9000001"},
-				release: "Windows 10 Version 21H2 for x64-based Systems",
-			},
-			want: []string{"9999999", "9000001"},
-		},
-		{
-			name:    "empty release keeps all KBs",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9000001", "9000002"},
-				release: "",
-			},
-			want: []string{"9000001", "9000002"},
-		},
-		{
-			name:    "ARM64 release filters out x64-only KB",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9000001", "9000002"},
-				release: "Windows 10 Version 21H2 for ARM64-based Systems",
-			},
-			want: []string{"9000002"},
-		},
-		{
-			name:    "bare cross-platform app KB kept across releases",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				kbs:     []string{"9000003"},
-				release: "Windows 10 Version 21H2 for x64-based Systems",
-			},
-			want: []string{"9000003"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
-				t.Fatalf("populate db. error = %v", err)
-			}
-
-			s, err := tt.config.New()
-			if err != nil {
-				t.Fatalf("new session. error = %v", err)
-			}
-
-			if err := s.Storage().Open(); err != nil {
-				t.Fatalf("open db connection. error = %v", err)
-			}
-			defer s.Storage().Close()
-
-			got, err := microsoft.FilterKBIDsByRelease(s.Storage(), tt.args.kbs, tt.args.release)
-			switch {
-			case tt.wantErr == nil && err != nil:
-				t.Errorf("filterKBIDsByRelease() unexpected error: %v", err)
-			case tt.wantErr != nil && err == nil:
-				t.Errorf("filterKBIDsByRelease() expected error has not occurred")
-			case tt.wantErr != nil && err != nil:
-				if tt.wantErr.Error() != err.Error() {
-					t.Errorf("filterKBIDsByRelease() error mismatch: want %v, got %v", tt.wantErr, err)
-				}
-			default:
-				if diff := cmp.Diff(tt.want, got); diff != "" {
-					t.Errorf("filterKBIDsByRelease() (-expected +got):\n%s", diff)
 				}
 			}
 		})
@@ -1658,124 +1851,28 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 	}
 }
 
-func TestExpandKBs_DataSourceFilter(t *testing.T) {
+func TestPartitionKBIDsByReleases(t *testing.T) {
+	// PartitionKBIDsByReleases is a pure function over the products map
+	// produced by ExpandKBs, so the fixtures here are hand-written — no DB
+	// needed.
 	type args struct {
-		applied     []string
-		unapplied   []string
-		datasources []sourceTypes.SourceID
-	}
-	tests := []struct {
-		name          string
-		fixture       string
-		config        session.Config
-		args          args
-		wantCovered   []string
-		wantUnapplied []string
-	}{
-		{
-			name:    "no filter walks every source's chain",
-			fixture: "testdata/fixtures/microsoft-supersession",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				applied: []string{"4012606"},
-			},
-			wantCovered:   []string{"4012606"},
-			wantUnapplied: []string{"4013429"},
-		},
-		{
-			name:    "filtering to a source that doesn't know the input KB stops the walk",
-			fixture: "testdata/fixtures/microsoft-supersession",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				applied:     []string{"4012606"},
-				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
-			},
-			wantCovered:   []string{"4012606"},
-			wantUnapplied: nil,
-		},
-		{
-			name:    "filtering to the source that owns the chain preserves it",
-			fixture: "testdata/fixtures/microsoft-supersession",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
-			args: args{
-				applied:     []string{"5000802"},
-				datasources: []sourceTypes.SourceID{"microsoft-cvrf"},
-			},
-			wantCovered:   []string{"5000802"},
-			wantUnapplied: []string{"5001330", "5003173", "5003637"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
-				t.Fatalf("populate db. error = %v", err)
-			}
-
-			s, err := tt.config.New()
-			if err != nil {
-				t.Fatalf("new session. error = %v", err)
-			}
-
-			if err := s.Storage().Open(); err != nil {
-				t.Fatalf("open db connection. error = %v", err)
-			}
-			defer s.Storage().Close()
-
-			var opts []microsoft.ExpandOption
-			if len(tt.args.datasources) > 0 {
-				opts = append(opts, microsoft.WithExpandDataSources(tt.args.datasources))
-			}
-			got, err := microsoft.ExpandKBs(s.Storage(), tt.args.applied, tt.args.unapplied, opts...)
-			if err != nil {
-				t.Fatalf("ExpandKBs() unexpected error: %v", err)
-			}
-
-			less := func(a, b string) bool { return a < b }
-			if diff := cmp.Diff(tt.wantCovered, got.Covered, cmpopts.SortSlices(less)); diff != "" {
-				t.Errorf("ExpandKBs() covered (-expected +got):\n%s", diff)
-			}
-			if diff := cmp.Diff(tt.wantUnapplied, got.Unapplied, cmpopts.SortSlices(less)); diff != "" {
-				t.Errorf("ExpandKBs() unapplied (-expected +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
-	type args struct {
+		products map[string][]string
 		kbs      []string
 		releases []string
 	}
 	tests := []struct {
 		name        string
-		fixture     string
-		config      session.Config
 		args        args
 		wantKept    []string
 		wantDropped []string
 	}{
 		{
-			name:    "empty releases keeps everything",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
+			name: "empty releases keeps everything",
 			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows 10 Version 21H2 for x64-based Systems"},
+					"9000002": {"Windows Server 2012 R2"},
+				},
 				kbs:      []string{"9000001", "9000002"},
 				releases: nil,
 			},
@@ -1783,14 +1880,12 @@ func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
 			wantDropped: nil,
 		},
 		{
-			name:    "single release matches both KBs",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
+			name: "single release matches both KBs",
 			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows 10 Version 21H2 for x64-based Systems"},
+					"9000002": {"Windows 10 Version 21H2 for x64-based Systems"},
+				},
 				kbs:      []string{"9000001", "9000002"},
 				releases: []string{"Windows 10 Version 21H2 for x64-based Systems"},
 			},
@@ -1798,14 +1893,15 @@ func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
 			wantDropped: nil,
 		},
 		{
-			name:    "single release matches only one KB",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
+			name: "single release matches only one KB",
 			args: args{
+				products: map[string][]string{
+					"9000001": {
+						"Windows 10 Version 21H2 for x64-based Systems",
+						"Windows Server 2012 R2",
+					},
+					"9000002": {"Windows 10 Version 21H2 for x64-based Systems"},
+				},
 				kbs:      []string{"9000001", "9000002"},
 				releases: []string{"Windows Server 2012 R2"},
 			},
@@ -1813,14 +1909,28 @@ func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
 			wantDropped: []string{"9000002"},
 		},
 		{
-			name:    "two releases keep both KBs via union semantics",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
+			name: "ARM64 release drops x64-only KB",
 			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows 10 Version 21H2 for x64-based Systems"},
+					"9000002": {
+						"Windows 10 Version 21H2 for ARM64-based Systems",
+						"Windows 10 Version 21H2 for x64-based Systems",
+					},
+				},
+				kbs:      []string{"9000001", "9000002"},
+				releases: []string{"Windows 10 Version 21H2 for ARM64-based Systems"},
+			},
+			wantKept:    []string{"9000002"},
+			wantDropped: []string{"9000001"},
+		},
+		{
+			name: "two releases keep both KBs via union semantics",
+			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows Server 2012 R2"},
+					"9000002": {"Windows 10 Version 21H2 for ARM64-based Systems"},
+				},
 				kbs: []string{"9000001", "9000002"},
 				releases: []string{
 					"Windows Server 2012 R2",
@@ -1831,42 +1941,57 @@ func TestPartitionKBIDsByReleases_MultiRelease(t *testing.T) {
 			wantDropped: nil,
 		},
 		{
-			name:    "release that matches none drops everything",
-			fixture: "testdata/fixtures/microsoft-cross-product",
-			config: session.Config{
-				Type:    "boltdb",
-				Path:    filepath.Join(t.TempDir(), "vuls.db"),
-				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
-			},
+			name: "release that matches none drops everything",
 			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows 10 Version 21H2 for x64-based Systems"},
+					"9000002": {"Windows 10 Version 21H2 for x64-based Systems"},
+				},
 				kbs:      []string{"9000001", "9000002"},
 				releases: []string{"Windows 11 Version 23H2 for x64-based Systems"},
 			},
 			wantKept:    []string{},
 			wantDropped: []string{"9000001", "9000002"},
 		},
+		{
+			name: "KB absent from products is kept",
+			args: args{
+				products: map[string][]string{
+					"9000001": {"Windows 10 Version 21H2 for x64-based Systems"},
+				},
+				kbs:      []string{"9999999", "9000001"},
+				releases: []string{"Windows 10 Version 21H2 for x64-based Systems"},
+			},
+			wantKept:    []string{"9999999", "9000001"},
+			wantDropped: nil,
+		},
+		{
+			name: "KB present but with empty product list is dropped",
+			args: args{
+				products: map[string][]string{
+					"9000001": {},
+				},
+				kbs:      []string{"9000001"},
+				releases: []string{"Windows 10 Version 21H2 for x64-based Systems"},
+			},
+			wantKept:    []string{},
+			wantDropped: []string{"9000001"},
+		},
+		{
+			name: "nil products keeps every KB",
+			args: args{
+				products: nil,
+				kbs:      []string{"9000001", "9000002"},
+				releases: []string{"Windows 10 Version 21H2 for x64-based Systems"},
+			},
+			wantKept:    []string{"9000001", "9000002"},
+			wantDropped: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
-				t.Fatalf("populate db. error = %v", err)
-			}
-
-			s, err := tt.config.New()
-			if err != nil {
-				t.Fatalf("new session. error = %v", err)
-			}
-
-			if err := s.Storage().Open(); err != nil {
-				t.Fatalf("open db connection. error = %v", err)
-			}
-			defer s.Storage().Close()
-
-			gotKept, gotDropped, err := microsoft.PartitionKBIDsByReleases(s.Storage(), tt.args.kbs, tt.args.releases)
-			if err != nil {
-				t.Fatalf("PartitionKBIDsByReleases() unexpected error: %v", err)
-			}
+			gotKept, gotDropped := microsoft.PartitionKBIDsByReleases(tt.args.products, tt.args.kbs, tt.args.releases)
 			if diff := cmp.Diff(tt.wantKept, gotKept); diff != "" {
 				t.Errorf("PartitionKBIDsByReleases() kept (-expected +got):\n%s", diff)
 			}


### PR DESCRIPTION
## Summary

Add `vuls db search kb-expand`, a diagnostic subcommand that traces how a host's `Applied` / `Unapplied` KB inputs are expanded through Microsoft KB supersession chains. The command exposes the same classification `detect` uses internally — `Covered` (inputs plus older KBs reached backward from applied) and `Unapplied` (discovered KBs not covered, plus inputs the scanner flagged unapplied) — and surfaces the per-edge data-source attribution that was previously only readable from code.

## Why

When `detect` flags a Microsoft CVE, the offending KB ID is often a KB the user never reported to vuls — it was discovered by walking `SupersededBy` (forward) and `Supersedes` (backward) chains from the host's input KBs through `microsoft-cvrf` / `microsoft-msuc` / `microsoft-bulletin`. Until now the only way to understand "why was KB X reported?" was to read the classifier. Three concrete pain points motivated this:

- **Auto-discovery is opaque.** "Applied 5000802 → flagged unapplied 5001330" — there is no UI affordance that says "...because 5001330 supersedes 5000802 according to microsoft-cvrf".
- **Source disagreements are common.** A KB's `SupersededBy` can be reported by cvrf at the KB level and by msuc at the per-Update level, sometimes inconsistently. There was no way to ask "which data source says what?".
- **Release / chain interaction is non-obvious.** When a Win10 host's walk pulls in a Server 2012 KB through a cross-product edge, the release filter drops it — but only at evaluation time, so dropped KBs were invisible.

## Usage

JSON output (default):

```
vuls db search kb-expand --applied 5000802 --unapplied 5001330
```

Tree output for investigation:

```
vuls db search kb-expand --applied 5000802 --explain
```

```
Inputs:
  Applied:   5000802
  Unapplied: (none)

Conflicts (in both Applied & Unapplied → treated as Unapplied):
  (none)

Supersession chains:

  5000802  [input:applied, covered]
    Superseded by:
      └─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]
          └─ [microsoft-cvrf, KB-level] 5003173  [discovered, unapplied]
              └─ [microsoft-cvrf, KB-level] 5003637  [discovered, unapplied]

Result:
  Covered:   5000802
  Unapplied: 5001330 5003173 5003637
```

Flags:

- `--applied <kbid>` / `--unapplied <kbid>` — repeatable. At least one required.
- `--release <release>` — repeatable. Filters covered/unapplied with union semantics and adds a `Release filter` section to the tree / JSON.
- `--datasource <id>` — repeatable. Restricts which Microsoft data source contributes edges and products. Same convention as `kb-info` / `kb-vuln`.
- `--explain` — renders the tree instead of JSON.

The tree handles both directions: input KBs at the newer end of a chain show a `Supersedes:` section for older KBs they cover; intermediate inputs show both sections. Cycles and revisits across sources are collapsed with `(→ see above)`.

## How

- `ExpandKBs(s, applied, unapplied, datasources) *ExpandResult` walks the supersession graph once and returns `Covered`, `Unapplied`, `Conflicts`, `Edges` (with `Source` and `Level` per edge), and `Products` (per-KB product set restricted to the allowed data sources). Single source of truth for both `Detect` and `SearchKBExpand`.
- `PartitionKBIDsByReleases(products, kbs, releases) (kept, dropped)` is a pure function over `ExpandResult.Products` — no DB access, no datasource argument. `Detect` uses it for the existing single-release filter; `SearchKBExpand` uses it for multi-release filtering and dropped-KB reporting.
- `Detect`'s behaviour is unchanged. The previous wrapper helpers (`classifyKBs`, `filterKBIDsByRelease`) collapse into direct `ExpandKBs` / `PartitionKBIDsByReleases` calls.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` pass.
- [x] `TestExpandKBs` exhaustively asserts `ExpandResult` (Covered / Unapplied / Conflicts / Edges / Products) across 11 cases: SupersededBy / Supersedes chains, dual-status KB preference, MSUC per-Update Supersedes, datasource filter inclusion / exclusion.
- [x] `TestPartitionKBIDsByReleases` (synthetic products, no DB) covers union semantics, ARM64 vs x64, KB absent from products kept, KB present with empty product list dropped.
- [x] `TestPrintKBExpandTree` exercises `--explain`: forward chain, backward Supersedes chain, intermediate input (both directions), multi-source edges with `(→ see above)`, cycle handling, single / multi release filter sections, datasource filter header.
- [x] Existing `TestDetect` fixtures unchanged.
