### PR TITLE
feat(detect/ospkg/microsoft): walk per-Update Supersedes for MSUC coverage

### DIFF
--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -153,7 +153,9 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 	// build a reverse edge map (superseding KB → list of superseded KBs) for
 	// the coverage BFS. Walking both directions makes the graph discovery
 	// robust against incomplete SupersededBy data: even if old→new links are
-	// missing, new→old Supersedes links can bridge the gap.
+	// missing, new→old Supersedes links can bridge the gap. Edges are sourced
+	// from both KB-level fields (e.g. CVRF) and per-Update fields (e.g. MSUC,
+	// wsusscn2) to maximize coverage across data sources.
 	visited := make(map[string]struct{})
 	revEdges := make(map[string][]string)
 
@@ -203,6 +205,17 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 				revEdges[kbid] = append(revEdges[kbid], sub.KBID)
 				if err := walk(sub.KBID); err != nil {
 					return errors.Wrapf(err, "walk supersedes from KB %s to %s", kbid, sub.KBID)
+				}
+			}
+			for _, u := range kb.Updates {
+				for _, sub := range u.Supersedes {
+					if sub.KBID == "" {
+						continue
+					}
+					revEdges[kbid] = append(revEdges[kbid], sub.KBID)
+					if err := walk(sub.KBID); err != nil {
+						return errors.Wrapf(err, "walk supersedes from KB %s to %s (via update)", kbid, sub.KBID)
+					}
 				}
 			}
 		}

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -658,6 +658,21 @@ func Test_classifyKBs(t *testing.T) {
 			wantCovered:   []string{"5000802", "5001330", "5003173", "5003637"},
 			wantUnapplied: nil,
 		},
+		{
+			name:    "per-update supersedes (MSUC) covers chain",
+			fixture: "testdata/fixtures/microsoft-update-supersedes",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				applied:   []string{"8000003"},
+				unapplied: nil,
+			},
+			wantCovered:   []string{"8000001", "8000002", "8000003"},
+			wantUnapplied: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/data/CVE/2024/CVE-2024-80002.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/data/CVE/2024/CVE-2024-80002.json
@@ -1,0 +1,47 @@
+{
+  "id": "CVE-2024-80002",
+  "vulnerabilities": [
+    {
+      "content": {
+        "id": "CVE-2024-80002",
+        "title": "Test vulnerability for per-update supersedes walk"
+      },
+      "segments": [
+        {
+          "ecosystem": "microsoft",
+          "tag": "Windows 10 Version 2004 for x64-based Systems"
+        }
+      ]
+    }
+  ],
+  "detections": [
+    {
+      "ecosystem": "microsoft",
+      "conditions": [
+        {
+          "criteria": {
+            "operator": "OR",
+            "criterias": [
+              {
+                "operator": "AND",
+                "criterions": [
+                  {
+                    "type": "kb",
+                    "kb": {
+                      "product": "Windows 10 Version 2004 for x64-based Systems",
+                      "kb_id": "8000001"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "tag": "Windows 10 Version 2004 for x64-based Systems"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc"
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/datasource.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/datasource.json
@@ -1,0 +1,11 @@
+{
+  "id": "microsoft-msuc",
+  "name": "Microsoft Update Catalog",
+  "raw": [
+    {
+      "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-microsoft-msuc",
+      "commit": "398798f3310f7beb113300ea3bf57a206feeb683",
+      "date": "2026-03-31T13:51:15Z"
+    }
+  ]
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000001.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000001.json
@@ -1,0 +1,16 @@
+{
+  "kb_id": "8000001",
+  "url": "https://support.microsoft.com/help/8000001",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000008001",
+      "title": "2024-01 Update for Windows 10 Version 2004 for x64-based Systems (KB8000001)",
+      "products": [
+        "Windows10"
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc"
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000002.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000002.json
@@ -1,0 +1,22 @@
+{
+  "kb_id": "8000002",
+  "url": "https://support.microsoft.com/help/8000002",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000008002",
+      "title": "2024-02 Update for Windows 10 Version 2004 for x64-based Systems (KB8000002)",
+      "products": [
+        "Windows10"
+      ],
+      "supersedes": [
+        {
+          "kb_id": "8000001",
+          "update_id": "00000000-0000-0000-0000-000000008001"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc"
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000003.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-update-supersedes/microsoft-msuc/microsoftkb/8000xxx/8000003.json
@@ -1,0 +1,22 @@
+{
+  "kb_id": "8000003",
+  "url": "https://support.microsoft.com/help/8000003",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000008003",
+      "title": "2024-03 Update for Windows 10 Version 2004 for x64-based Systems (KB8000003)",
+      "products": [
+        "Windows10"
+      ],
+      "supersedes": [
+        {
+          "kb_id": "8000002",
+          "update_id": "00000000-0000-0000-0000-000000008002"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc"
+  }
+}


### PR DESCRIPTION
## Summary

classifyKBs walks the KB supersession graph in both directions to build coverage. Previously it walked:

- KB-level `SupersededBy` (forward)
- KB-level `Supersedes` (backward)
- `Updates[].SupersededBy` (forward, per-Update)

This PR adds the symmetric missing edge: `Updates[].Supersedes` (backward, per-Update).

## Why

MSUC / wsusscn2 data sources store supersession relations exclusively per Update (`Updates[].SupersededBy` / `Updates[].Supersedes`). The KB-level `Supersedes` field on MSUC KB objects is empty, so MSUC's backward edges were entirely unused. Meanwhile, CVRF populates KB-level fields and doesn't use Updates[] for supersession, so the forward/backward asymmetry went unnoticed until comparing gost vs vuls2 on Server 2008 R2 (Monthly Rollup era) where MSUC is the primary source for chain information.

With this change, backward chain discovery benefits from MSUC edges just like forward discovery already does.

## Changes

- `classifyKBs`: add an inner loop iterating `kb.Updates[].Supersedes` mirroring the existing `kb.Updates[].SupersededBy` walk.
- Update the comment block describing edge sourcing (KB-level + per-Update).
- New test fixture `microsoft-update-supersedes`: 3 KBs (8000001→8000002→8000003) linked solely through `Updates[].Supersedes`, verifying all three are marked covered when only the newest is applied.

## Verification

- `go test ./pkg/detect/ospkg/microsoft/...` all pass, including the new `per-update supersedes (MSUC) covers chain` case.
- Ran full detection comparison on Windows Server 2008 R2 before/after: vuls2 detection count decreases (fewer stale unapplied KBs), consistent with improved chain discovery.