### PR TITLE
chore(deps): bump github.com/MaineK00n/vuls-data-update to ea21d0d8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MaineK00n/vuls2
 go 1.26
 
 require (
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260423125038-ca8c9432d996
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:ZeayjCT6JMMfoL9cS3w1BvBogxRi+I3QmabI8jL7+HQ=
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260423125038-ca8c9432d996 h1:XQgm641+rH0vb1d8FoI/9r1LcdBnzWE/SqEoJ3e5Aoc=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260423125038-ca8c9432d996/go.mod h1:zgZp2Gf0JQ8pPSHgDSxm+KFKf8twW+rWice7TIY7zEs=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9 h1:i9IAWrcmxhYJSTjhtINsFOAFmnfJusQQGNWIJnpkjcc=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260428075914-ea21d0d8e4c9/go.mod h1:zgZp2Gf0JQ8pPSHgDSxm+KFKf8twW+rWice7TIY7zEs=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=


### PR DESCRIPTION
Pulls in vuls-data-update#783 (merged into nightly), which adds the new remediation package and Mitigations/Workarounds fields on the extracted vulnerability/advisory Content type. vuls2 stores extracted Content verbatim per data source, so the bump alone is sufficient for the new fields to flow through `db add` / `db get` to downstream consumers (e.g. vuls0).

`go build ./...` and `go test ./...` both pass.