### PR TITLE
fix(detect/ospkg/microsoft): allowlist KB-criterion app families

### DIFF
--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -352,18 +352,164 @@ var microsoftPackageNameRules = []normalizeRule{
 	},
 }
 
+// filterMicrosoftKBProduct decides whether a KB's product is relevant to
+// the given host release. Two cases:
+//
+//   - Suffix products ("... on <release>" / "... installed on <release>")
+//     are kept iff their suffix equals release (cross-product safety).
+//   - Bare products are kept iff either they name a cross-platform app
+//     that we actively want KB-criterion-based detection to evaluate
+//     (see isKBCriterionApp), or they exactly equal the host release.
+//     The default-filter direction means OS-named bare products must
+//     match release exactly, while niche/legacy app products that are
+//     unlikely to be installed are dropped — which prevents KB-criterion
+//     "covered" matches from contaminating detections via the
+//     supersession graph (e.g. Win7 host falsely flagging old "Media
+//     Center TV Pack" or "Microsoft Windows Script Host" bulletins).
+//
+// AcceptProducts (gated by scanner-observed installed packages and
+// applied / unapplied KB targets) is still the final arbiter for cases
+// where this filter passes a product through.
 func filterMicrosoftKBProduct(product, release string) bool {
 	if release == "" {
 		return true
 	}
-	suffix := extractOSSuffix(product)
-	if suffix == "" {
-		// Bare OS name (e.g. "Windows 10 Version 21H2 for x64-based Systems",
-		// "Windows Server 2012 R2"). Must match release exactly to avoid
-		// cross-product contamination from multi-product KBs.
-		return product == release
+	if suffix := extractOSSuffix(product); suffix != "" {
+		return suffix == release
 	}
-	return suffix == release
+	if isKBCriterionApp(product) {
+		return true
+	}
+	return product == release
+}
+
+// isKBCriterionApp reports whether a bare product (no " on " suffix) is
+// a cross-platform Microsoft application family that we want
+// KB-criterion-based detection to evaluate regardless of host OS
+// release. Products outside this allowlist are subject to strict
+// release-equality filtering — that is the desired behaviour for both
+// OS-named bare products (where release equality is the right test) and
+// for niche/legacy apps that are unlikely to be present on most scanned
+// hosts and would otherwise trigger false positives via the
+// supersession-graph "covered" path. Examples currently filtered:
+// "Media Center TV Pack for Windows Vista", "Microsoft Surface with
+// Windows RT", "Windows Virtual PC", "Windows Live OneCare",
+// "Windows Essentials", "Microsoft Windows Script Host".
+//
+// Note that several "Windows ..." prefixed product families are
+// intentionally allowlisted because Microsoft still ships
+// KB-criterion-based updates for them across multiple host releases —
+// e.g. Windows Defender, Windows Admin Center, Windows Malicious
+// Software Removal Tool, Windows Media Player, Internet Security and
+// Acceleration Server. Treat these as cross-platform apps, not as
+// host-OS products.
+//
+// Add an entry here when a Microsoft product family becomes a regular
+// target for KB-criterion-based detection (Patch Tuesday, monthly
+// security updates, or equivalent). Removing an entry strips silent
+// detection from that family.
+func isKBCriterionApp(product string) bool {
+	p := strings.TrimPrefix(product, "Microsoft ")
+
+	// Family allowlist. A product matches when, after the optional
+	// "Microsoft " trim, it equals the family token or starts with the
+	// token followed by " " / "," / ":" (covering naming variants like
+	// "Office 2016 (32-bit edition)" / "SharePoint Server, Version ..."
+	// / "Platform SDK Redistributable: GDI+").
+	appFamilies := []string{
+		// "Internet Explorer" is the only major Microsoft app without a
+		// "Microsoft " vendor prefix in the DB; trim above is a no-op for
+		// it, so listing the family here picks up "Internet Explorer 11"
+		// / "Internet Explorer 6.0" naturally.
+		"Internet Explorer",
+
+		// "2007 Microsoft Office System" is a Microsoft 2007-only
+		// marketing name where the family token is embedded in the middle
+		// of the product string. The 2010+ generation reverted to
+		// "Microsoft Office <year>", so this entry is closed and won't
+		// grow. Prefix matching is intentional here: it covers both the
+		// family itself and suite variants like
+		// "2007 Microsoft Office System Service Pack 3" — both should be
+		// evaluated against KB criteria.
+		"2007 Microsoft Office System",
+
+		// Office suite & individual apps.
+		"Office", "Word", "Excel", "PowerPoint", "Outlook", "Access",
+		"OneNote", "Publisher", "Visio", "Project", "InfoPath",
+		"FrontPage", "Live Meeting", "Communicator",
+
+		// SharePoint / collaboration.
+		"SharePoint", "Sharepoint",
+		"Windows SharePoint Services",
+		"Groove", "Groove Server",
+		"FAST Search Server",
+		"Business Productivity Servers",
+
+		// Mail / messaging / telephony.
+		"Exchange", "Lync", "Skype",
+
+		// Database servers and drivers.
+		"SQL Server",
+		"Data Access Components", "Data Engine",
+		"OLE DB Driver", "OLE DB Provider",
+		"Report Viewer Redistributable",
+
+		// Web / mainframe / commerce / management servers.
+		"Internet Information Services", "Internet Information Server",
+		"Internet Security and Acceleration Server",
+		"Host Integration Server",
+		"Commerce Server", "Content Management Server",
+		"Endpoint Configuration Manager",
+
+		// Developer tooling and runtimes.
+		"Visual Studio", "Visual Basic", "Visual C++", "Visual FoxPro",
+		".NET", "ASP.NET", "ASP.NET Core",
+		"Expression Web", "Expression Studio",
+		"Platform SDK Redistributable",
+
+		// Browsers and runtimes.
+		"Edge", "Silverlight",
+		"MSXML", "XML Core Services",
+
+		// Business / management products.
+		"Dynamics", "BizTalk", "Forefront", "System Center",
+
+		// Office productivity suite (legacy).
+		"Works", "Works Suite",
+
+		// File-format converters.
+		"Open XML File Format Converter",
+
+		// Azure-prefixed cross-platform apps.
+		"Azure File Sync", "Azure Pack",
+
+		// "Windows "-prefixed apps (NOT OS releases) that we still want
+		// KB-criterion-based detection to evaluate. Other "Windows "-
+		// prefixed legacy apps without ongoing security updates (Live
+		// OneCare, Essentials, Journal Viewer, Messenger, Script Host,
+		// Media Player on EOL'd Windows, ...) deliberately stay outside
+		// this list.
+		"Windows Defender",
+		"Windows Admin Center",
+		"Windows Update Assistant",
+		"Windows Malicious Software Removal Tool",
+		"Windows Azure Pack",
+		"Windows Media Player",
+	}
+	for _, fam := range appFamilies {
+		if p == fam {
+			return true
+		}
+		if len(p) > len(fam) {
+			switch p[len(fam)] {
+			case ' ', ',', ':':
+				if strings.HasPrefix(p, fam) {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func extractOSSuffix(product string) string {

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -409,6 +409,58 @@ func TestDetect(t *testing.T) {
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
 		},
 		{
+			name:    "detect bare cross-platform app KB criterion on Windows host",
+			fixture: "testdata/fixtures/microsoft-bare-app-kb",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+				sr: scanTypes.ScanResult{
+					Family:  ecosystemTypes.EcosystemTypeMicrosoft,
+					Release: "Windows 10 Version 21H2 for x64-based Systems",
+					MicrosoftKB: scanTypes.MicrosoftKB{
+						Unapplied: []string{"8800001"},
+					},
+				},
+				concurrency: 1,
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2024-88001": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Microsoft Office 2016 (32-bit edition)",
+															KBID:    "8800001",
+														},
+													},
+													Accepts: criterionTypes.AcceptQueries{KB: criterionTypes.KB{Unapplied: true}},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Microsoft Office 2016 (32-bit edition)"),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:    "cross-product KB filtered: Win10 host does not detect Server 2012 condition",
 			fixture: "testdata/fixtures/microsoft-cross-product",
 			config: session.Config{
@@ -809,6 +861,20 @@ func Test_filterKBIDsByRelease(t *testing.T) {
 			},
 			want: []string{"9000002"},
 		},
+		{
+			name:    "bare cross-platform app KB kept across releases",
+			fixture: "testdata/fixtures/microsoft-cross-product",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				kbs:     []string{"9000003"},
+				release: "Windows 10 Version 21H2 for x64-based Systems",
+			},
+			want: []string{"9000003"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -926,14 +992,6 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "no suffix, non-matching product filtered",
-			args: args{
-				product: "Microsoft Edge (Chromium-based)",
-				release: "Windows 10 Version 1607 for x64-based Systems",
-			},
-			want: false,
-		},
-		{
 			name: "bare OS name matching release passes",
 			args: args{
 				product: "Windows 10 Version 21H2 for x64-based Systems",
@@ -948,6 +1006,470 @@ func Test_filterMicrosoftKBProduct(t *testing.T) {
 				release: "Windows 10 Version 21H2 for x64-based Systems",
 			},
 			want: false,
+		},
+		{
+			name: "bare Windows 8.1 SKU matching release passes",
+			args: args{
+				product: "Windows 8.1 for x64-based Systems",
+				release: "Windows 8.1 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Server comma-separated SKU matches family token",
+			args: args{
+				product: "Windows Server, Version 1903 (Server Core installation)",
+				release: "Windows Server, Version 1903 (Server Core installation)",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Server comma-separated SKU cross-product filtered",
+			args: args{
+				product: "Windows Server, Version 1903 (Server Core installation)",
+				release: "Windows 11 Version 23H2 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare Azure Stack HCI OS matching release passes",
+			args: args{
+				product: "Azure Stack HCI OS 22H2",
+				release: "Azure Stack HCI OS 22H2",
+			},
+			want: true,
+		},
+		{
+			name: "bare Azure Stack HCI OS cross-product filtered",
+			args: args{
+				product: "Azure Stack HCI OS 22H2",
+				release: "Windows 11 Version 23H2 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare cross-platform Edge product passes",
+			args: args{
+				product: "Microsoft Edge (Chromium-based)",
+				release: "Windows 10 Version 1607 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare cross-platform Office product passes",
+			args: args{
+				product: "Microsoft Office 2016 (32-bit edition)",
+				release: "Windows 10 Version 21H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare cross-platform .NET product passes",
+			args: args{
+				product: ".NET 6.0",
+				release: "Windows 11 Version 23H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare cross-platform Azure File Sync product passes",
+			args: args{
+				product: "Azure File Sync v18.0",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Admin Center (cross-OS tool) passes",
+			args: args{
+				product: "Windows Admin Center",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Malicious Software Removal Tool passes",
+			args: args{
+				product: "Windows Malicious Software Removal Tool 64-bit",
+				release: "Windows 11 Version 23H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Update Assistant passes",
+			args: args{
+				product: "Windows Update Assistant",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Azure Pack passes",
+			args: args{
+				product: "Windows Azure Pack Rollup 13.1",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare microsoft-bulletin Windows XP product cross-product filtered",
+			args: args{
+				product: "Microsoft Windows XP Professional x64 Edition Service Pack 2",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows XP product matching release passes",
+			args: args{
+				product: "Microsoft Windows XP Professional x64 Edition Service Pack 2",
+				release: "Microsoft Windows XP Professional x64 Edition Service Pack 2",
+			},
+			want: true,
+		},
+		{
+			name: "bare microsoft-bulletin Server 2003 SP2 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Server 2003 Service Pack 2",
+				release: "Windows Server 2012 R2",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Server 2003 Itanium cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Server 2003 for Itanium-based Systems Service Pack 2",
+				release: "Windows 8.1 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows 2000 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows 2000 Service Pack 4",
+				release: "Windows Server 2008 for x64-based Systems Service Pack 2",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows XP SP3 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows XP Service Pack 3",
+				release: "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare versionless Windows RT cross-product filtered",
+			args: args{
+				product: "Windows RT",
+				release: "Windows 8.1 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare versionless Windows RT matching release passes",
+			args: args{
+				product: "Windows RT",
+				release: "Windows RT",
+			},
+			want: true,
+		},
+		{
+			name: "bare versionless Windows Vista cross-product filtered",
+			args: args{
+				product: "Windows Vista",
+				release: "Windows Server 2008 for x64-based Systems Service Pack 2",
+			},
+			want: false,
+		},
+		{
+			name: "bare versionless Windows Vista matching release passes",
+			args: args{
+				product: "Windows Vista",
+				release: "Windows Vista",
+			},
+			want: true,
+		},
+		{
+			name: "bare Microsoft Office (cross-platform with Microsoft prefix) passes",
+			args: args{
+				product: "Microsoft Office 2019 (64-bit edition)",
+				release: "Windows Server 2019",
+			},
+			want: true,
+		},
+		{
+			name: "bare Microsoft SharePoint Server (cross-platform) passes",
+			args: args{
+				product: "Microsoft SharePoint Server 2019",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Microsoft SQL Server (cross-platform) passes",
+			args: args{
+				product: "Microsoft SQL Server 2022 for x64-based Systems (GDR)",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Microsoft Exchange Server (cross-platform) passes",
+			args: args{
+				product: "Microsoft Exchange Server 2019 Cumulative Update 14",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Microsoft Dynamics (cross-platform) passes",
+			args: args{
+				product: "Microsoft Dynamics 365 Business Central 2024 Release Wave 2",
+				release: "Windows Server 2022",
+			},
+			want: true,
+		},
+		{
+			name: "bare Skype for Business (cross-platform) passes",
+			args: args{
+				product: "Skype for Business 2016 (64-bit)",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Small Business Server cross-product filtered",
+			args: args{
+				product: "Windows Small Business Server 2003 R2",
+				release: "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Home Server cross-product filtered",
+			args: args{
+				product: "Windows Home Server",
+				release: "Windows Server 2012",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows Me cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Me",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows NT4 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows NT4",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows NT Server 4.0 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows NT Server 4.0 Service Pack 6a",
+				release: "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Services for UNIX cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Services for UNIX 3.5",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare microsoft-bulletin Windows 98 cross-product filtered",
+			args: args{
+				product: "Microsoft Windows 98 Second Edition",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Media Player (cross-platform app) passes",
+			args: args{
+				product: "Windows Media Player 11",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: true,
+		},
+		{
+			name: "bare Windows Messenger (legacy EOL, NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Windows Messenger 4.7",
+				release: "Windows XP Service Pack 3",
+			},
+			want: false,
+		},
+		{
+			name: "bare Microsoft Windows SharePoint Services (cross-platform app) passes",
+			args: args{
+				product: "Microsoft Windows SharePoint Services 3.0 Service Pack 2 (32-bit version)",
+				release: "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+			},
+			want: true,
+		},
+		{
+			name: "bare versionless Microsoft Windows XP cross-product filtered",
+			args: args{
+				product: "Microsoft Windows XP",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare versionless Microsoft Windows Millennium Edition cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Millennium Edition",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Internet Information Services (allowlisted server) passes",
+			args: args{
+				product: "Internet Information Services 5.0",
+				release: "Windows Server 2008 for x64-based Systems Service Pack 2",
+			},
+			want: true,
+		},
+		{
+			name: "bare ISA Server (allowlisted server) passes",
+			args: args{
+				product: "Microsoft Internet Security and Acceleration Server 2000",
+				release: "Windows Server 2008 for x64-based Systems Service Pack 2",
+			},
+			want: true,
+		},
+		{
+			name: "bare Works Suite (allowlisted productivity legacy) passes",
+			args: args{
+				product: "Microsoft Works Suite 2004",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: true,
+		},
+		{
+			name: "bare 2007 Microsoft Office System (legacy naming) passes",
+			args: args{
+				product: "2007 Microsoft Office System Service Pack 3",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Internet Explorer (no Microsoft prefix) passes",
+			args: args{
+				product: "Internet Explorer 11",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Media Center TV Pack (NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Media Center TV Pack",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Microsoft Surface (NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Microsoft Surface Pro 4",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare Microsoft Virtual PC (NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Microsoft Virtual PC 2007",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Live OneCare (legacy EOL, NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Windows Live OneCare",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Essentials (legacy EOL, NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Windows Essentials 2012",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Windows Journal Viewer (legacy EOL, NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Windows Journal Viewer",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: false,
+		},
+		{
+			name: "bare Microsoft Windows Script Host (legacy, NOT in allowlist) cross-product filtered",
+			args: args{
+				product: "Microsoft Windows Script Host 5.5",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: false,
+		},
+		{
+			name: "bare Visual Studio (allowlisted dev) passes",
+			args: args{
+				product: "Microsoft Visual Studio 2015 Update 3",
+				release: "Windows 10 Version 22H2 for x64-based Systems",
+			},
+			want: true,
+		},
+		{
+			name: "bare Forefront (allowlisted) passes",
+			args: args{
+				product: "Microsoft Forefront UAG 2010",
+				release: "Windows Server 2008 R2 for x64-based Systems Service Pack 1",
+			},
+			want: true,
+		},
+		{
+			name: "bare BizTalk (allowlisted) passes",
+			args: args{
+				product: "Microsoft BizTalk Server 2020",
+				release: "Windows Server 2019",
+			},
+			want: true,
+		},
+		{
+			name: "bare Outlook Express (legacy variant via Outlook prefix) passes",
+			args: args{
+				product: "Outlook Express 5.5",
+				release: "Windows XP Service Pack 3",
+			},
+			want: true,
+		},
+		{
+			name: "bare MSXML Core Services (allowlisted runtime) passes",
+			args: args{
+				product: "MSXML 4.0 Service Pack 2",
+				release: "Windows 7 for x64-based Systems Service Pack 1",
+			},
+			want: true,
 		},
 		{
 			name: "matching release passes",

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/data/CVE/2024/CVE-2024-88001.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/data/CVE/2024/CVE-2024-88001.json
@@ -1,0 +1,65 @@
+{
+  "id": "CVE-2024-88001",
+  "vulnerabilities": [
+    {
+      "content": {
+        "id": "CVE-2024-88001",
+        "title": "Test bare-app KB criterion",
+        "severity": [
+          {
+            "type": "vendor",
+            "source": "secure@microsoft.com",
+            "vendor": "Important"
+          }
+        ],
+        "references": [
+          {
+            "source": "secure@microsoft.com",
+            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-88001"
+          }
+        ],
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-01T00:00:00Z"
+      },
+      "segments": [
+        {
+          "ecosystem": "microsoft",
+          "tag": "Microsoft Office 2016 (32-bit edition)"
+        }
+      ]
+    }
+  ],
+  "detections": [
+    {
+      "ecosystem": "microsoft",
+      "conditions": [
+        {
+          "criteria": {
+            "operator": "OR",
+            "criterias": [
+              {
+                "operator": "AND",
+                "criterions": [
+                  {
+                    "type": "kb",
+                    "kb": {
+                      "product": "Microsoft Office 2016 (32-bit edition)",
+                      "kb_id": "8800001"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "tag": "Microsoft Office 2016 (32-bit edition)"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-cvrf",
+    "raws": [
+      "vuls-data-raw-microsoft-cvrf/test/CVE-2024-88001.json"
+    ]
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/datasource.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/datasource.json
@@ -1,0 +1,11 @@
+{
+  "id": "microsoft-cvrf",
+  "name": "Microsoft CVRF",
+  "raw": [
+    {
+      "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-microsoft-cvrf",
+      "commit": "0000000000000000000000000000000000000000",
+      "date": "2025-01-01T00:00:00Z"
+    }
+  ]
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/microsoftkb/8800xxx/8800001.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-bare-app-kb/microsoft-cvrf/microsoftkb/8800xxx/8800001.json
@@ -1,0 +1,13 @@
+{
+  "kb_id": "8800001",
+  "url": "https://support.microsoft.com/help/8800001",
+  "products": [
+    "Microsoft Office 2016 (32-bit edition)"
+  ],
+  "data_source": {
+    "id": "microsoft-cvrf",
+    "raws": [
+      "vuls-data-raw-microsoft-cvrf/test/CVE-2024-88001.json"
+    ]
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-cross-product/microsoft-cvrf/data/CVE/2024/CVE-2024-90003.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-cross-product/microsoft-cvrf/data/CVE/2024/CVE-2024-90003.json
@@ -1,0 +1,65 @@
+{
+  "id": "CVE-2024-90003",
+  "vulnerabilities": [
+    {
+      "content": {
+        "id": "CVE-2024-90003",
+        "title": "Test Cross-Platform App KB",
+        "severity": [
+          {
+            "type": "vendor",
+            "source": "secure@microsoft.com",
+            "vendor": "Important"
+          }
+        ],
+        "references": [
+          {
+            "source": "secure@microsoft.com",
+            "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2024-90003"
+          }
+        ],
+        "published": "2024-01-01T00:00:00Z",
+        "modified": "2024-01-01T00:00:00Z"
+      },
+      "segments": [
+        {
+          "ecosystem": "microsoft",
+          "tag": "Microsoft Office 2016 (32-bit edition)"
+        }
+      ]
+    }
+  ],
+  "detections": [
+    {
+      "ecosystem": "microsoft",
+      "conditions": [
+        {
+          "criteria": {
+            "operator": "OR",
+            "criterias": [
+              {
+                "operator": "AND",
+                "criterions": [
+                  {
+                    "type": "kb",
+                    "kb": {
+                      "product": "Microsoft Office 2016 (32-bit edition)",
+                      "kb_id": "9000003"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "tag": "Microsoft Office 2016 (32-bit edition)"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-cvrf",
+    "raws": [
+      "vuls-data-raw-microsoft-cvrf/test/CVE-2024-90003.json"
+    ]
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-cross-product/microsoft-cvrf/microsoftkb/9000xxx/9000003.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-cross-product/microsoft-cvrf/microsoftkb/9000xxx/9000003.json
@@ -1,0 +1,13 @@
+{
+  "kb_id": "9000003",
+  "url": "https://support.microsoft.com/help/9000003",
+  "products": [
+    "Microsoft Office 2016 (32-bit edition)"
+  ],
+  "data_source": {
+    "id": "microsoft-cvrf",
+    "raws": [
+      "vuls-data-raw-microsoft-cvrf/test/CVE-2024-90003.json"
+    ]
+  }
+}


### PR DESCRIPTION
## Problem

`filterMicrosoftKBProduct` previously rejected any bare product (no `" on "` / `" installed on "` suffix) that did not equal the host release exactly. This dropped cross-platform application products such as:

- `.NET 6.0`
- `Microsoft Office 2016 (32-bit edition)`
- `Microsoft SharePoint Server 2019`
- `Microsoft SQL Server 2022 for x64-based Systems (GDR)`
- `Azure File Sync v18.0`

`filterKBIDsByRelease` therefore removed those KBs from `unappliedKBs` / `coveredKBs`, and the KB-criterion path missed unapplied Office / .NET / SharePoint / Exchange / SQL Server / Dynamics KBs even when the scanner reported them.

## Fix

Replace the OS-vs-app split with an explicit **cross-platform-app allowlist** (`isKBCriterionApp`).

```go
func filterMicrosoftKBProduct(product, release string) bool {
    if release == "" {
        return true
    }
    if suffix := extractOSSuffix(product); suffix != "" {
        return suffix == release   // " on " / " installed on " suffix matches release
    }
    if isKBCriterionApp(product) {
        return true                // cross-platform app — let KB criterion evaluate
    }
    return product == release      // OS-bare and niche app: strict release equality
}
```

`isKBCriterionApp` enumerates Microsoft's actually-patched cross-platform product lineup: Office / Word / Excel / PowerPoint / Outlook / Access / OneNote / Publisher / Visio / Project / InfoPath, SharePoint, Exchange, Lync, Skype, SQL Server, Visual Studio / Visual Basic / Visual C++, .NET / ASP.NET / ASP.NET Core, Edge, Silverlight, Internet Explorer, 2007 Microsoft Office System, MSXML / XML Core Services, Dynamics, BizTalk, Forefront, System Center, IIS / ISA Server, Host Integration Server, Commerce Server, Endpoint Configuration Manager, Defender, Admin Center, MSRT, Update Assistant, Azure File Sync, Azure Pack, Media Player, etc.

Cross-product safety still comes from `AcceptProducts`, which is gated by scanner-observed installed packages and applied / unapplied KB targets.

## Why an app allowlist instead of an OS enumeration

1. **Both responsibilities of `filterMicrosoftKBProduct` want the same answer.** It gates `vcm` registration in `Detect` and gates `coveredKBs` / `unappliedKBs` in `filterKBIDsByRelease`. Cross-platform apps are relevant if actively patched; OS-named bare products are relevant only when they equal the host release; everything else is noise.

2. **Enumerating the OS side cannot eliminate false positives via the supersession-graph "covered" path.** With the previous design, KB 2978742 (applied on Win7) introduced `Media Center TV Pack` into `vcm`, and KB 2494132 (an older Media Center KB sharing the same product) ended up flagged covered-but-not-applied because it was discovered through the supersession graph but missing from `coveredKBs` — yielding three Win7 false positives (MS11-015 / MS11-076 / MS12-004). Allowlisting keeps `Media Center TV Pack` out of `vcm` entirely, closing that path.

3. **The allowlist is bounded by Microsoft's actual product lineup.** New numbered Windows OS releases (every few years) no longer require code changes. New app families (added through Patch Tuesday) require an explicit allowlist update, which is a more deliberate maintenance signal than silent OS misclassification.

## Verification

End-to-end against a 26-host Windows scan corpus and the production `vuls.db` (10,566 microsoft KBs / 3,758 unique products):

- **+0 / -0** detection diff vs the pre-PR baseline (no false positives, no false negatives introduced)
- 961 unique app products (7,291 KB instances) pass through the allowlist
- 288 unique OS-bare-or-niche products (16,333 KB instances) fall through to release-equality
- 2,509 unique `" on "` suffix products handled unchanged

## Test plan

- [x] `go test ./pkg/detect/ospkg/microsoft/...` — all existing fixtures pass
- [x] New unit cases in `Test_filterMicrosoftKBProduct` for: cross-platform app passes, OS-bare release-equality, microsoft-bulletin legacy products (`Microsoft Windows XP/Server 2003/2000`) filtered, Internet Explorer / 2007 Microsoft Office System pass, version-less Windows RT/Vista filtered, niche/legacy products (Media Center TV Pack / Surface / Virtual PC / Live OneCare / Essentials) filtered
- [x] Cross-product fixture (`microsoft-cross-product`) verifies `Microsoft Office 2016 (32-bit edition)` KB on Windows host emits the cross-platform CVE
- [x] Re-ran the full bench corpus: 0 detection delta vs `nightly`