### PR TITLE
feat(detect/ospkg/microsoft): include forward superseders in vcm scope

### DIFF
--- a/pkg/detect/ospkg/microsoft/export_test.go
+++ b/pkg/detect/ospkg/microsoft/export_test.go
@@ -5,4 +5,5 @@ var (
 	FilterKBIDsByRelease          = filterKBIDsByRelease
 	NormalizeMicrosoftPackageName = normalizeMicrosoftPackageName
 	FilterMicrosoftKBProduct      = filterMicrosoftKBProduct
+	ForwardSupersedersFromApplied = forwardSupersedersFromApplied
 )

--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -55,7 +55,60 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 		}
 	}
 
-	for _, kbid := range append(sr.MicrosoftKB.Applied, sr.MicrosoftKB.Unapplied...) {
+	// Register vcm products from applied + unapplied (input) plus the
+	// forward-only superseders of applied (KBs reachable via SupersededBy
+	// edges only). Forward expansion adds the products of newer KBs that
+	// host should apply but hasn't (e.g. a current Defender KB whose newer
+	// revision targets new platforms), without leaking products from the
+	// backward Supersedes chain (which would pull in stale era-mismatched
+	// products like IE 5.01 KBs on modern hosts via cross-product
+	// supersession edges). filterMicrosoftKBProduct still gates each
+	// product per-entry so cross-OS products picked up by the forward walk
+	// (e.g. a Win11 24H2 cumulative superseded by a Server 2025 one) do
+	// not leak into vcm.
+	//
+	// Seed the forward walk from Applied \ Unapplied to mirror
+	// classifyKBs' "prefer unapplied" rule: a KB reported as both applied
+	// and unapplied (pending reboot / rolled back) is treated as unapplied
+	// and therefore not used to expand the should-have-applied frontier.
+	unappliedSet := make(map[string]struct{}, len(sr.MicrosoftKB.Unapplied))
+	for _, kbid := range sr.MicrosoftKB.Unapplied {
+		if kbid == "" {
+			continue
+		}
+		unappliedSet[kbid] = struct{}{}
+	}
+	forwardSeeds := make([]string, 0, len(sr.MicrosoftKB.Applied))
+	for _, kbid := range sr.MicrosoftKB.Applied {
+		if kbid == "" {
+			continue
+		}
+		if _, ok := unappliedSet[kbid]; ok {
+			continue
+		}
+		forwardSeeds = append(forwardSeeds, kbid)
+	}
+	forwardKBs, err := forwardSupersedersFromApplied(s, forwardSeeds)
+	if err != nil {
+		return nil, errors.Wrap(err, "forward superseders from applied")
+	}
+
+	// Deduplicate before iterating: applied / unapplied / forwardKBs may
+	// share IDs (e.g. forwardKBs can intersect Unapplied), and a duplicate
+	// would trigger redundant GetMicrosoftKB lookups.
+	vcmKBSet := make(map[string]struct{}, len(sr.MicrosoftKB.Applied)+len(unappliedSet)+len(forwardKBs))
+	for _, kbid := range sr.MicrosoftKB.Applied {
+		if kbid != "" {
+			vcmKBSet[kbid] = struct{}{}
+		}
+	}
+	for kbid := range unappliedSet {
+		vcmKBSet[kbid] = struct{}{}
+	}
+	for _, kbid := range forwardKBs {
+		vcmKBSet[kbid] = struct{}{}
+	}
+	for kbid := range vcmKBSet {
 		m, err := s.GetMicrosoftKB(kbid)
 		if err != nil {
 			if errors.Is(err, dbTypes.ErrNotFoundMicrosoftKB) {
@@ -272,6 +325,80 @@ func classifyKBs(s session.Storage, applied []string, unapplied []string) (cover
 	}
 
 	return coveredKBs, unappliedKBs, nil
+}
+
+// forwardSupersedersFromApplied returns the KBs reachable from applied via
+// forward-only BFS through SupersededBy edges (both KB-level and per-Update),
+// excluding the applied seeds themselves. The result is intended for
+// expanding vcm product registration: products of newer KBs that supersede
+// applied represent platforms host should-but-hasn't applied yet, and need
+// to be in vcm so KB criteria targeting those products can be evaluated.
+//
+// This is intentionally narrower than classifyKBs's bidirectional walk:
+// the backward Supersedes chain is excluded because following it from
+// applied or unapplied input pulls in old historical KBs (e.g. KB279328
+// for Internet Explorer 5.01 from 2001) whose products would otherwise
+// leak cross-era bulletins (MS01-MS09 Internet Explorer entries) into
+// modern hosts via the isKBCriterionApp allowlist.
+func forwardSupersedersFromApplied(s session.Storage, applied []string) ([]string, error) {
+	// Seed visited and queue from a deduplicated, non-empty applied list so
+	// each starting KB is fetched at most once and downstream BFS treats
+	// duplicates as a single seed.
+	appliedSet := make(map[string]struct{}, len(applied))
+	queue := make([]string, 0, len(applied))
+	for _, kb := range applied {
+		if kb == "" {
+			continue
+		}
+		if _, ok := appliedSet[kb]; ok {
+			continue
+		}
+		appliedSet[kb] = struct{}{}
+		queue = append(queue, kb)
+	}
+	visited := maps.Clone(appliedSet)
+	for head := 0; head < len(queue); head++ {
+		cur := queue[head]
+		m, err := s.GetMicrosoftKB(cur)
+		if err != nil {
+			if errors.Is(err, dbTypes.ErrNotFoundMicrosoftKB) {
+				continue
+			}
+			return nil, errors.Wrapf(err, "get microsoft kb %s", cur)
+		}
+		for _, kb := range m {
+			for _, sup := range kb.SupersededBy {
+				if sup.KBID == "" {
+					continue
+				}
+				if _, ok := visited[sup.KBID]; ok {
+					continue
+				}
+				visited[sup.KBID] = struct{}{}
+				queue = append(queue, sup.KBID)
+			}
+			for _, u := range kb.Updates {
+				for _, sup := range u.SupersededBy {
+					if sup.KBID == "" {
+						continue
+					}
+					if _, ok := visited[sup.KBID]; ok {
+						continue
+					}
+					visited[sup.KBID] = struct{}{}
+					queue = append(queue, sup.KBID)
+				}
+			}
+		}
+	}
+	var out []string
+	for kb := range visited {
+		if _, ok := appliedSet[kb]; ok {
+			continue
+		}
+		out = append(out, kb)
+	}
+	return out, nil
 }
 
 // filterKBIDsByRelease removes KBs whose products are all irrelevant to

--- a/pkg/detect/ospkg/microsoft/microsoft.go
+++ b/pkg/detect/ospkg/microsoft/microsoft.go
@@ -67,10 +67,13 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 	// (e.g. a Win11 24H2 cumulative superseded by a Server 2025 one) do
 	// not leak into vcm.
 	//
-	// Seed the forward walk from Applied \ Unapplied to mirror
-	// classifyKBs' "prefer unapplied" rule: a KB reported as both applied
-	// and unapplied (pending reboot / rolled back) is treated as unapplied
-	// and therefore not used to expand the should-have-applied frontier.
+	// Seed the forward walk from Applied (without subtracting Unapplied).
+	// classifyKBs' prefer-unapplied rule narrows the coverage-BFS source so
+	// a dual-status KB doesn't credit itself as proof of patching; the vcm
+	// forward walk has the opposite goal (track the should-have-applied
+	// frontier products), so dual-status KBs should still expand the
+	// frontier. filterMicrosoftKBProduct + AcceptProducts gate at evaluation
+	// time so over-registered products are handled safely.
 	unappliedSet := make(map[string]struct{}, len(sr.MicrosoftKB.Unapplied))
 	for _, kbid := range sr.MicrosoftKB.Unapplied {
 		if kbid == "" {
@@ -81,9 +84,6 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, sr scanTypes.
 	forwardSeeds := make([]string, 0, len(sr.MicrosoftKB.Applied))
 	for _, kbid := range sr.MicrosoftKB.Applied {
 		if kbid == "" {
-			continue
-		}
-		if _, ok := unappliedSet[kbid]; ok {
 			continue
 		}
 		forwardSeeds = append(forwardSeeds, kbid)

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -764,6 +764,135 @@ func Test_classifyKBs(t *testing.T) {
 	}
 }
 
+func Test_forwardSupersedersFromApplied(t *testing.T) {
+	type args struct {
+		applied []string
+	}
+	tests := []struct {
+		name    string
+		fixture string
+		config  session.Config
+		args    args
+		want    []string
+		wantErr error
+	}{
+		{
+			name:    "empty applied",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: nil},
+			want: nil,
+		},
+		{
+			name:    "applied at chain head: discovers forward chain",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: []string{"5000802"}},
+			want: []string{"5001330", "5003173", "5003637"},
+		},
+		{
+			name:    "applied at chain tail: nothing newer",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: []string{"5003637"}},
+			want: nil,
+		},
+		{
+			name:    "duplicate applied IDs: deduplicated",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: []string{"5000802", "5000802", "", "5000802"}},
+			want: []string{"5001330", "5003173", "5003637"},
+		},
+		{
+			name:    "applied not in DB: silently skipped",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: []string{"9999999"}},
+			want: nil,
+		},
+		{
+			name:    "applied in middle: returns only forward, no backward",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{applied: []string{"5001330"}},
+			want: []string{"5003173", "5003637"},
+		},
+		{
+			name:    "per-Update SupersededBy chain: traversed",
+			fixture: "testdata/fixtures/microsoft-supersession",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			// 5005001 / 5005002 / 5005003 are connected only via
+			// updates[].superseded_by (microsoft-msuc fixture). KB-level
+			// superseded_by is empty for all three, so a passing result
+			// confirms that the per-Update edge is followed.
+			args: args{applied: []string{"5005001"}},
+			want: []string{"5005002", "5005003"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
+				t.Fatalf("populate db. error = %v", err)
+			}
+
+			s, err := tt.config.New()
+			if err != nil {
+				t.Fatalf("new session. error = %v", err)
+			}
+
+			if err := s.Storage().Open(); err != nil {
+				t.Fatalf("open db connection. error = %v", err)
+			}
+			defer s.Storage().Close()
+
+			got, err := microsoft.ForwardSupersedersFromApplied(s.Storage(), tt.args.applied)
+			switch {
+			case tt.wantErr == nil && err != nil:
+				t.Errorf("forwardSupersedersFromApplied() unexpected error: %v", err)
+			case tt.wantErr != nil && err == nil:
+				t.Errorf("forwardSupersedersFromApplied() expected error has not occurred")
+			case tt.wantErr != nil && err != nil:
+				if tt.wantErr.Error() != err.Error() {
+					t.Errorf("forwardSupersedersFromApplied() error mismatch: want %v, got %v", tt.wantErr, err)
+				}
+			default:
+				if diff := cmp.Diff(tt.want, got, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+					t.Errorf("forwardSupersedersFromApplied() (-expected +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}
+
 func Test_filterKBIDsByRelease(t *testing.T) {
 	type args struct {
 		kbs     []string

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/datasource.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/datasource.json
@@ -1,0 +1,11 @@
+{
+  "id": "microsoft-msuc",
+  "name": "Microsoft Update Catalog",
+  "raw": [
+    {
+      "url": "ghcr.io/vulsio/vuls-data-db:vuls-data-raw-microsoft-msuc",
+      "commit": "0000000000000000000000000000000000000000",
+      "date": "2026-03-31T13:51:15Z"
+    }
+  ]
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005001.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005001.json
@@ -1,0 +1,22 @@
+{
+  "kb_id": "5005001",
+  "url": "https://support.microsoft.com/help/5005001",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000005001",
+      "catalog_url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=5005001",
+      "superseded_by": [
+        {
+          "kb_id": "5005002",
+          "update_id": "00000000-0000-0000-0000-000000005002"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc",
+    "raws": [
+      "vuls-data-raw-microsoft-msuc/00000000-0000-0000-0000-000000005001.json"
+    ]
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005002.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005002.json
@@ -1,0 +1,22 @@
+{
+  "kb_id": "5005002",
+  "url": "https://support.microsoft.com/help/5005002",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000005002",
+      "catalog_url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=5005002",
+      "superseded_by": [
+        {
+          "kb_id": "5005003",
+          "update_id": "00000000-0000-0000-0000-000000005003"
+        }
+      ]
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc",
+    "raws": [
+      "vuls-data-raw-microsoft-msuc/00000000-0000-0000-0000-000000005002.json"
+    ]
+  }
+}

--- a/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005003.json
+++ b/pkg/detect/ospkg/microsoft/testdata/fixtures/microsoft-supersession/microsoft-msuc/microsoftkb/5005xxx/5005003.json
@@ -1,0 +1,16 @@
+{
+  "kb_id": "5005003",
+  "url": "https://support.microsoft.com/help/5005003",
+  "updates": [
+    {
+      "update_id": "00000000-0000-0000-0000-000000005003",
+      "catalog_url": "https://catalog.update.microsoft.com/v7/site/Search.aspx?q=5005003"
+    }
+  ],
+  "data_source": {
+    "id": "microsoft-msuc",
+    "raws": [
+      "vuls-data-raw-microsoft-msuc/00000000-0000-0000-0000-000000005003.json"
+    ]
+  }
+}


### PR DESCRIPTION
## What

Expand vcm product registration to include not only the host's input
applied/unapplied KBs but also the KBs reachable from applied via
forward-only BFS through SupersededBy edges (KB-level and per-Update).

## Why

vcm gates which RootIDs are evaluated for KB-criterion detection. When
a CVE's criterion product is registered exclusively by a newer KB that
supersedes a currently applied KB, the product never lands in vcm and
the CVE is silently skipped.

A concrete example: CVE-2024-21315 is fixed by KB5034830 (\"Microsoft
Defender for Endpoint for Windows on Windows Server 2012\"), reachable
from a Server 2012 host's Defender chain via SupersededBy. Without vcm
expansion the criterion product is absent and the CVE goes undetected.

The walk is intentionally **forward-only**. The bidirectional walk used
by `classifyKBs` follows Supersedes chains backward into very old KBs
(e.g. KB279328 for Internet Explorer 5.01 from 2001). Combined with
the \"Internet Explorer\" entry in `isKBCriterionApp`, that path leaks
era-mismatched bulletin products (MS01-* etc.) into modern hosts' vcm
and produces cross-era false positives on Win11 22H2 / Server 2025.
Forward-only walk avoids the leak by construction.

`filterMicrosoftKBProduct` still gates each registered product per-
entry, so cross-OS products picked up by the forward walk (e.g. a
Win11 24H2 cumulative superseded by a Server 2025 one) do not leak
across release boundaries.

## How

- New helper `forwardSupersedersFromApplied(s, applied)` does forward-
  only BFS via SupersededBy edges, returning the discovered KBs minus
  the seeds.
- The existing vcm registration loop now iterates over
  `applied + unapplied + forwardSupersedersFromApplied(applied)`.
- `classifyKBs` and the `query.KB` shape are unchanged.

## Testing

- `go build ./...`: passes.
- `go test ./pkg/detect/ospkg/microsoft/...`: existing tests pass.
- Measured against a corpus of 27 Windows host scan fixtures with gost
  as a recall reference:
  - 8 CVEs of recall recovery (CVEs gost catches but vuls2 used to
    miss): CVE-2024-21315 on Server 2012, CVE-2018-8260 /
    CVE-2021-24111 / CVE-2022-30130 / CVE-2022-41064 on Win7, etc.
  - 38 CVEs of recall advance (CVEs gost structurally misses due to
    its \"skip on no-evidence\" detection logic, but vuls2 with this
    change correctly identifies as unfixed). Verified by checking
    that the host's applied set transitively does NOT supersede the
    fix KB. Concentrated on Server 2012 (37 CVEs from 2018-2019 IE
    patches) plus 1 on Server 2008 R2.
  - 0 false positives among the new detections.
  - Win11 22H2 MS-* bulletin counts remain 0 (no cross-era leak).

## Limitations: product-presence FP risk

The expansion adds OS-suffix-matched products from newer KBs into vcm
(e.g. \"Microsoft .NET Framework 4.8 on Windows 7 ...\", \"Internet
Explorer 11 on Windows Server 2012\"). KB-criterion firing on these
products assumes the named component is actually installed on the
host. The scanner does not currently report installation state for
built-in / optional Windows components, so detections may include
false positives on hosts that do not have the specific component
(e.g. IE 11 enabled on a Server 2012 without IE 11 installed). This
amplifies an existing v-old surface; it does not introduce a new
class of FP.

Validated via random sampling on vuls.db (10,567 KBs):

- Realistic case (applied = 200 random KBs targeting the host's
  release, 5 trials each across 9 release types): bare-family
  allowlist leak = **0**; OS-suffix additions = 0-9 unique products
  per release (.NET version variants, IE 10/11, Edge IE Mode,
  Defender for Endpoint, XML Core Services, etc.).
- Pathological case (applied = 200 random KBs from the entire DB,
  3 trials per release): bare-family leak = 29-102 per trial via
  existing `isKBCriterionApp` entries (Microsoft Office, Microsoft
  Exchange Server, etc.). This is **not** realistic for real applied
  lists, which are OS-realistic, and reflects an existing v-old
  characteristic rather than a regression.

Cross-OS leakage is structurally prevented by
`filterMicrosoftKBProduct`'s suffix matching (4000+ cross-OS products
per trial were correctly filtered out in the pathological test).