### PR TITLE
feat(db/diff): per-target change rate threshold overrides

### DIFF
--- a/pkg/cmd/diff/db/db.go
+++ b/pkg/cmd/diff/db/db.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"github.com/MakeNowJust/heredoc"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -17,23 +18,31 @@ func NewCmd() *cobra.Command {
 		changeRateThreshold: 0,
 		debug:               false,
 	}
-	// Parsed in PreRunE so a malformed --change-rate-threshold-override aborts
-	// before opening any DB; RunE reads it back via this closure.
-	var overrides map[string]float64
-
 	cmd := &cobra.Command{
 		Use:   "db <baseline-db> <target-db>",
 		Short: "compare detection data directly between two vuls DBs",
-		Args:  cobra.ExactArgs(2),
-		PreRunE: func(_ *cobra.Command, _ []string) error {
-			m, err := override.Parse(options.changeRateThresholdOverrides)
+		Example: heredoc.Doc(`
+		# fail when any ecosystem drifts more than 10%
+		$ vuls diff db ./baseline.db ./target.db --change-rate-threshold 10
+
+		# relax ubuntu:26.04 (new-distro churn) and fedora:45 individually,
+		# keep every other ecosystem at the 10% default
+		$ vuls diff db ./baseline.db ./target.db \
+		    --change-rate-threshold 10 \
+		    --change-rate-threshold-override ubuntu:26.04=25 \
+		    --change-rate-threshold-override fedora:45=15
+
+		# comma-separated form is equivalent
+		$ vuls diff db ./baseline.db ./target.db \
+		    --change-rate-threshold 10 \
+		    --change-rate-threshold-override 'ubuntu:26.04=25,fedora:45=15'
+		`),
+		Args: cobra.ExactArgs(2),
+		RunE: func(_ *cobra.Command, args []string) error {
+			overrides, err := override.Parse(options.changeRateThresholdOverrides)
 			if err != nil {
 				return errors.Wrap(err, "parse change-rate-threshold-override")
 			}
-			overrides = m
-			return nil
-		},
-		RunE: func(_ *cobra.Command, args []string) error {
 			return diffdb.DiffBoltDB(
 				args[0], args[1],
 				diffdb.WithChangeRateThreshold(options.changeRateThreshold),

--- a/pkg/cmd/diff/db/db.go
+++ b/pkg/cmd/diff/db/db.go
@@ -1,34 +1,51 @@
 package db
 
 import (
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/MaineK00n/vuls2/pkg/cmd/diff/internal/override"
 	diffdb "github.com/MaineK00n/vuls2/pkg/db/diff/db"
 )
 
 func NewCmd() *cobra.Command {
 	options := struct {
-		changeRateThreshold float64
-		debug               bool
+		changeRateThreshold          float64
+		changeRateThresholdOverrides []string
+		debug                        bool
 	}{
 		changeRateThreshold: 0,
 		debug:               false,
 	}
+	// Parsed in PreRunE so a malformed --change-rate-threshold-override aborts
+	// before opening any DB; RunE reads it back via this closure.
+	var overrides map[string]float64
 
 	cmd := &cobra.Command{
 		Use:   "db <baseline-db> <target-db>",
 		Short: "compare detection data directly between two vuls DBs",
 		Args:  cobra.ExactArgs(2),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			m, err := override.Parse(options.changeRateThresholdOverrides)
+			if err != nil {
+				return errors.Wrap(err, "parse change-rate-threshold-override")
+			}
+			overrides = m
+			return nil
+		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return diffdb.DiffBoltDB(
 				args[0], args[1],
 				diffdb.WithChangeRateThreshold(options.changeRateThreshold),
+				diffdb.WithChangeRateThresholdOverrides(overrides),
 				diffdb.WithDebug(options.debug),
 			)
 		},
 	}
 
 	cmd.Flags().Float64Var(&options.changeRateThreshold, "change-rate-threshold", options.changeRateThreshold, "change rate (%) threshold per ecosystem; exit non-zero if exceeded")
+	cmd.Flags().StringSliceVar(&options.changeRateThresholdOverrides, "change-rate-threshold-override", nil,
+		"per-ecosystem override of the threshold; format: <ecosystem>=<rate> (repeatable; comma-separated entries also accepted)")
 	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
 
 	return cmd

--- a/pkg/cmd/diff/detection/detection.go
+++ b/pkg/cmd/diff/detection/detection.go
@@ -6,17 +6,23 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/MaineK00n/vuls2/pkg/cmd/diff/internal/override"
 	diffdetection "github.com/MaineK00n/vuls2/pkg/db/diff/detection"
 )
 
 func NewCmd() *cobra.Command {
 	options := struct {
-		changeRateThreshold float64
-		debug               bool
+		changeRateThreshold          float64
+		changeRateThresholdOverrides []string
+		debug                        bool
 	}{
 		changeRateThreshold: 0,
 		debug:               false,
 	}
+
+	// Parsed in PreRunE so a malformed --change-rate-threshold-override aborts
+	// before any vuls0 invocation; RunE reads it back via this closure.
+	var overrides map[string]float64
 
 	cmd := &cobra.Command{
 		Use:   "detection <scan-results-dir> <baseline-db> <baseline-vuls0-binary> <target-db> <target-vuls0-binary>",
@@ -30,18 +36,26 @@ func NewCmd() *cobra.Command {
 				}
 				args[i] = abs
 			}
+			m, err := override.Parse(options.changeRateThresholdOverrides)
+			if err != nil {
+				return errors.Wrap(err, "parse change-rate-threshold-override")
+			}
+			overrides = m
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
 			return diffdetection.Diff(
 				args[0], args[1], args[2], args[3], args[4],
 				diffdetection.WithChangeRateThreshold(options.changeRateThreshold),
+				diffdetection.WithChangeRateThresholdOverrides(overrides),
 				diffdetection.WithDebug(options.debug),
 			)
 		},
 	}
 
 	cmd.Flags().Float64Var(&options.changeRateThreshold, "change-rate-threshold", options.changeRateThreshold, "change rate (%) threshold per scan result file; exit non-zero if exceeded")
+	cmd.Flags().StringSliceVar(&options.changeRateThresholdOverrides, "change-rate-threshold-override", nil,
+		"per-file override of the threshold; format: <file-basename>=<rate> (repeatable; comma-separated entries also accepted)")
 	cmd.Flags().BoolVarP(&options.debug, "debug", "d", options.debug, "debug mode")
 
 	return cmd

--- a/pkg/cmd/diff/detection/detection.go
+++ b/pkg/cmd/diff/detection/detection.go
@@ -3,6 +3,7 @@ package detection
 import (
 	"path/filepath"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -20,14 +21,34 @@ func NewCmd() *cobra.Command {
 		debug:               false,
 	}
 
-	// Parsed in PreRunE so a malformed --change-rate-threshold-override aborts
-	// before any vuls0 invocation; RunE reads it back via this closure.
-	var overrides map[string]float64
-
 	cmd := &cobra.Command{
 		Use:   "detection <scan-results-dir> <baseline-db> <baseline-vuls0-binary> <target-db> <target-vuls0-binary>",
 		Short: "compare detection results between baseline and target (binary, DB) pairs",
-		Args:  cobra.ExactArgs(5),
+		Example: heredoc.Doc(`
+		# fail when any scan-result file drifts more than 5%
+		$ vuls diff detection \
+		    ./scan-results \
+		    ./baseline.db ./vuls0 \
+		    ./target.db ./vuls0 \
+		    --change-rate-threshold 5
+
+		# relax debian_13 (new CVEs landed) without weakening the default
+		$ vuls diff detection \
+		    ./scan-results \
+		    ./baseline.db ./vuls0 \
+		    ./target.db ./vuls0 \
+		    --change-rate-threshold 5 \
+		    --change-rate-threshold-override debian_13=8
+
+		# repeated and comma-separated forms are interchangeable
+		$ vuls diff detection \
+		    ./scan-results \
+		    ./baseline.db ./vuls0 \
+		    ./target.db ./vuls0 \
+		    --change-rate-threshold 5 \
+		    --change-rate-threshold-override 'debian_13=8,ubuntu_2604=12'
+		`),
+		Args: cobra.ExactArgs(5),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			for i := range args {
 				abs, err := filepath.Abs(args[i])
@@ -36,14 +57,13 @@ func NewCmd() *cobra.Command {
 				}
 				args[i] = abs
 			}
-			m, err := override.Parse(options.changeRateThresholdOverrides)
-			if err != nil {
-				return errors.Wrap(err, "parse change-rate-threshold-override")
-			}
-			overrides = m
 			return nil
 		},
 		RunE: func(_ *cobra.Command, args []string) error {
+			overrides, err := override.Parse(options.changeRateThresholdOverrides)
+			if err != nil {
+				return errors.Wrap(err, "parse change-rate-threshold-override")
+			}
 			return diffdetection.Diff(
 				args[0], args[1], args[2], args[3], args[4],
 				diffdetection.WithChangeRateThreshold(options.changeRateThreshold),

--- a/pkg/cmd/diff/internal/override/override.go
+++ b/pkg/cmd/diff/internal/override/override.go
@@ -24,26 +24,26 @@ func Parse(entries []string) (map[string]float64, error) {
 	for _, e := range entries {
 		k, v, ok := strings.Cut(e, "=")
 		if !ok {
-			return nil, errors.Errorf("missing %q separator: %q", "=", e)
+			return nil, errors.Errorf("unexpected override entry. expected: %q, actual: %q", "<key>=<rate>", e)
 		}
 		k = strings.TrimSpace(k)
 		v = strings.TrimSpace(v)
 		if k == "" {
-			return nil, errors.Errorf("empty key: %q", e)
+			return nil, errors.Errorf("unexpected override key. expected: non-empty, actual: %q (entry: %q)", k, e)
 		}
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
-			return nil, errors.Wrapf(err, "parse rate %q (entry %q)", v, e)
+			return nil, errors.Wrapf(err, "unexpected override rate. expected: numeric, actual: %q (entry: %q)", v, e)
 		}
 		// strconv.ParseFloat happily accepts "NaN" / "Inf"; both produce
 		// surprising downstream behavior (NaN: every comparison false,
 		// every diff FAILs even when within threshold; Inf: every diff
 		// PASSes regardless of rate). Refuse them up front.
 		if math.IsNaN(f) || math.IsInf(f, 0) {
-			return nil, errors.Errorf("non-finite rate not allowed: %q", e)
+			return nil, errors.Errorf("unexpected override rate. expected: finite, actual: %v (entry: %q)", f, e)
 		}
 		if f < 0 {
-			return nil, errors.Errorf("negative rate not allowed: %q", e)
+			return nil, errors.Errorf("unexpected override rate. expected: >= 0, actual: %v (entry: %q)", f, e)
 		}
 		if _, dup := m[k]; dup {
 			slog.Warn("duplicate override key, last wins", "key", k, "rate", f)

--- a/pkg/cmd/diff/internal/override/override.go
+++ b/pkg/cmd/diff/internal/override/override.go
@@ -15,7 +15,7 @@ import (
 // Parse converts a slice of "<key>=<rate>" entries into a map. Whitespace
 // around the key and rate is tolerated. Duplicate keys are accepted with the
 // last value winning and a warning logged. Returns an error for malformed
-// entries (missing "=", empty key, non-numeric rate, negative rate).
+// entries (missing "=", empty key, non-numeric / non-finite / negative rate).
 func Parse(entries []string) (map[string]float64, error) {
 	if len(entries) == 0 {
 		return nil, nil

--- a/pkg/cmd/diff/internal/override/override.go
+++ b/pkg/cmd/diff/internal/override/override.go
@@ -5,6 +5,7 @@ package override
 
 import (
 	"log/slog"
+	"math"
 	"strconv"
 	"strings"
 
@@ -33,6 +34,13 @@ func Parse(entries []string) (map[string]float64, error) {
 		f, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			return nil, errors.Wrapf(err, "parse rate %q (entry %q)", v, e)
+		}
+		// strconv.ParseFloat happily accepts "NaN" / "Inf"; both produce
+		// surprising downstream behavior (NaN: every comparison false,
+		// every diff FAILs even when within threshold; Inf: every diff
+		// PASSes regardless of rate). Refuse them up front.
+		if math.IsNaN(f) || math.IsInf(f, 0) {
+			return nil, errors.Errorf("non-finite rate not allowed: %q", e)
 		}
 		if f < 0 {
 			return nil, errors.Errorf("negative rate not allowed: %q", e)

--- a/pkg/cmd/diff/internal/override/override.go
+++ b/pkg/cmd/diff/internal/override/override.go
@@ -1,0 +1,46 @@
+// Package override parses repeated `--change-rate-threshold-override` flag
+// values of the form `<key>=<rate>` into a map. Shared between the diff db
+// and diff detection commands so both accept the same input syntax.
+package override
+
+import (
+	"log/slog"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+// Parse converts a slice of "<key>=<rate>" entries into a map. Whitespace
+// around the key and rate is tolerated. Duplicate keys are accepted with the
+// last value winning and a warning logged. Returns an error for malformed
+// entries (missing "=", empty key, non-numeric rate, negative rate).
+func Parse(entries []string) (map[string]float64, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]float64, len(entries))
+	for _, e := range entries {
+		k, v, ok := strings.Cut(e, "=")
+		if !ok {
+			return nil, errors.Errorf("missing %q separator: %q", "=", e)
+		}
+		k = strings.TrimSpace(k)
+		v = strings.TrimSpace(v)
+		if k == "" {
+			return nil, errors.Errorf("empty key: %q", e)
+		}
+		f, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parse rate %q (entry %q)", v, e)
+		}
+		if f < 0 {
+			return nil, errors.Errorf("negative rate not allowed: %q", e)
+		}
+		if _, dup := m[k]; dup {
+			slog.Warn("duplicate override key, last wins", "key", k, "rate", f)
+		}
+		m[k] = f
+	}
+	return m, nil
+}

--- a/pkg/cmd/diff/internal/override/override_test.go
+++ b/pkg/cmd/diff/internal/override/override_test.go
@@ -82,6 +82,21 @@ func TestParse(t *testing.T) {
 			entries: []string{"ubuntu:26.04=-5"},
 			wantErr: true,
 		},
+		{
+			name:    "NaN rate",
+			entries: []string{"ubuntu:26.04=NaN"},
+			wantErr: true,
+		},
+		{
+			name:    "+Inf rate",
+			entries: []string{"ubuntu:26.04=+Inf"},
+			wantErr: true,
+		},
+		{
+			name:    "-Inf rate",
+			entries: []string{"ubuntu:26.04=-Inf"},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/cmd/diff/internal/override/override_test.go
+++ b/pkg/cmd/diff/internal/override/override_test.go
@@ -1,0 +1,100 @@
+package override_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/MaineK00n/vuls2/pkg/cmd/diff/internal/override"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []string
+		want    map[string]float64
+		wantErr bool
+	}{
+		{
+			name:    "nil entries",
+			entries: nil,
+			want:    nil,
+		},
+		{
+			name:    "empty slice",
+			entries: []string{},
+			want:    nil,
+		},
+		{
+			name:    "single entry",
+			entries: []string{"ubuntu:26.04=25"},
+			want:    map[string]float64{"ubuntu:26.04": 25},
+		},
+		{
+			name:    "multiple entries",
+			entries: []string{"ubuntu:26.04=25", "debian_13=8", "redhat:9=12.5"},
+			want: map[string]float64{
+				"ubuntu:26.04": 25,
+				"debian_13":    8,
+				"redhat:9":     12.5,
+			},
+		},
+		{
+			name:    "whitespace tolerated",
+			entries: []string{"  ubuntu:26.04 = 25 ", "\tdebian_13=8\t"},
+			want: map[string]float64{
+				"ubuntu:26.04": 25,
+				"debian_13":    8,
+			},
+		},
+		{
+			name:    "explicit zero kept",
+			entries: []string{"strict-target=0"},
+			want:    map[string]float64{"strict-target": 0},
+		},
+		{
+			name:    "duplicate key last wins",
+			entries: []string{"ubuntu:26.04=10", "ubuntu:26.04=25"},
+			want:    map[string]float64{"ubuntu:26.04": 25},
+		},
+		{
+			name:    "rate over 100 allowed",
+			entries: []string{"new-distro=150"},
+			want:    map[string]float64{"new-distro": 150},
+		},
+		{
+			name:    "missing separator",
+			entries: []string{"ubuntu:26.04"},
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			entries: []string{"=25"},
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric rate",
+			entries: []string{"ubuntu:26.04=abc"},
+			wantErr: true,
+		},
+		{
+			name:    "negative rate",
+			entries: []string{"ubuntu:26.04=-5"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := override.Parse(tt.entries)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Parse() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -160,8 +160,6 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 		return errors.Wrap(err, "compute diffs")
 	}
 
-	warnUnusedOverrides(o.changeRateThresholdOverrides, results)
-
 	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
 	if err != nil {
 		return errors.Wrap(err, "generate report")
@@ -184,26 +182,6 @@ func resolveThreshold(key string, def float64, overrides map[string]float64) (fl
 		return v, true
 	}
 	return def, false
-}
-
-// warnUnusedOverrides logs a warning for each override key that did not match
-// any compared ecosystem. Catches typos and stale entries before they silently
-// rot in the workflow file.
-func warnUnusedOverrides(overrides map[string]float64, results []EcosystemDiff) {
-	if len(overrides) == 0 {
-		return
-	}
-	used := make(map[string]bool, len(results))
-	for _, d := range results {
-		if d.ThresholdOverridden {
-			used[string(d.Ecosystem)] = true
-		}
-	}
-	for k := range overrides {
-		if !used[k] {
-			slog.Warn("change-rate-threshold override key did not match any ecosystem", "key", k)
-		}
-	}
 }
 
 func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64, overrides map[string]float64) ([]EcosystemDiff, error) {

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -168,7 +168,10 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 
 	if !pass {
-		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (default %.1f%%)", o.changeRateThreshold)
+		// Resolved per-ecosystem threshold (default vs override) is rendered in
+		// the report's Override column, so the exit error stays threshold-free
+		// to avoid implying the default was the one that tripped.
+		return errors.New("diff failed: detection and/or KB change rate exceeded the applicable threshold for at least one ecosystem; see report for details")
 	}
 	return nil
 }

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -193,10 +193,16 @@ func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64, ov
 	// New ecosystems in the target are feature additions, not regressions,
 	// so they are intentionally excluded from change rate calculation.
 	for _, eco := range baselineEcos {
+		// Resolve the per-ecosystem threshold here so diffEcosystem stays a
+		// pure per-target function that doesn't need the overrides map.
+		threshold := changeRateThreshold
+		if v, ok := overrides[string(eco)]; ok {
+			threshold = v
+		}
 		g.Go(func() error {
 			slog.Debug("ecosystem diff start", "ecosystem", eco)
 
-			d, err := diffEcosystem(baselineDB, targetDB, eco, changeRateThreshold, overrides)
+			d, err := diffEcosystem(baselineDB, targetDB, eco, threshold)
 			if err != nil {
 				return errors.Wrapf(err, "diff ecosystem %s", string(eco))
 			}
@@ -259,7 +265,9 @@ func getEcosystems(db *bolt.DB) ([]ecosystemTypes.Ecosystem, error) {
 
 // diffEcosystem compares an ecosystem between two DBs by diffing each of its
 // sub-buckets (detection, kb) independently. Either sub-bucket may be absent.
-func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem, changeRateThreshold float64, overrides map[string]float64) (EcosystemDiff, error) {
+// Override resolution is the caller's responsibility — this function applies
+// `threshold` verbatim.
+func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem, threshold float64) (EcosystemDiff, error) {
 	diff := EcosystemDiff{Ecosystem: ecosystem}
 
 	if err := baselineDB.View(func(btx *bolt.Tx) error {
@@ -297,13 +305,8 @@ func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosy
 
 	diff.DetectionChangeRate = changeRate(diff.BaselineCriterions, diff.TargetCriterions, diff.MatchedCriterions)
 	diff.KBChangeRate = changeRate(diff.BaselineKBs, diff.TargetKBs, diff.MatchedKBs)
-	diff.Threshold = func() float64 {
-		if v, ok := overrides[string(ecosystem)]; ok {
-			return v
-		}
-		return changeRateThreshold
-	}()
-	diff.Pass = diff.DetectionChangeRate <= diff.Threshold && diff.KBChangeRate <= diff.Threshold
+	diff.Threshold = threshold
+	diff.Pass = diff.DetectionChangeRate <= threshold && diff.KBChangeRate <= threshold
 	return diff, nil
 }
 

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -54,18 +54,8 @@ func (o changeRateThresholdOverridesOption) apply(opts *options) {
 // change rate threshold. Keys are ecosystem identifiers (e.g. "ubuntu:26.04");
 // values are percentages. Missing keys fall back to the default supplied via
 // WithChangeRateThreshold. A nil or empty map preserves prior behavior.
-//
-// The provided map is defensively copied; callers may mutate or reuse `m`
-// after this call returns without affecting an in-flight or subsequent diff.
 func WithChangeRateThresholdOverrides(m map[string]float64) Option {
-	if len(m) == 0 {
-		return changeRateThresholdOverridesOption(nil)
-	}
-	cp := make(map[string]float64, len(m))
-	for k, v := range m {
-		cp[k] = v
-	}
-	return changeRateThresholdOverridesOption(cp)
+	return changeRateThresholdOverridesOption(m)
 }
 
 type writerOption struct{ w io.Writer }

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -164,9 +164,9 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 
 	if !pass {
-		// Resolved per-ecosystem threshold (default vs override) is rendered in
-		// the report's Override column, so the exit error stays threshold-free
-		// to avoid implying the default was the one that tripped.
+		// Resolved per-ecosystem threshold is rendered per row in the report's
+		// Threshold column, so the exit error stays threshold-free to avoid
+		// implying the default was the one that tripped.
 		return errors.New("diff failed: detection and/or KB change rate exceeded the applicable threshold for at least one ecosystem; see report for details")
 	}
 	return nil

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -24,9 +24,10 @@ import (
 )
 
 type options struct {
-	changeRateThreshold float64
-	writer              io.Writer
-	debug               bool
+	changeRateThreshold          float64
+	changeRateThresholdOverrides map[string]float64
+	writer                       io.Writer
+	debug                        bool
 }
 
 type Option interface {
@@ -41,6 +42,20 @@ func (o changeRateThresholdOption) apply(opts *options) {
 
 func WithChangeRateThreshold(r float64) Option {
 	return changeRateThresholdOption(r)
+}
+
+type changeRateThresholdOverridesOption map[string]float64
+
+func (o changeRateThresholdOverridesOption) apply(opts *options) {
+	opts.changeRateThresholdOverrides = map[string]float64(o)
+}
+
+// WithChangeRateThresholdOverrides supplies per-ecosystem overrides of the
+// change rate threshold. Keys are ecosystem identifiers (e.g. "ubuntu:26.04");
+// values are percentages. Missing keys fall back to the default supplied via
+// WithChangeRateThreshold. A nil or empty map preserves prior behavior.
+func WithChangeRateThresholdOverrides(m map[string]float64) Option {
+	return changeRateThresholdOverridesOption(m)
 }
 
 type writerOption struct{ w io.Writer }
@@ -97,7 +112,13 @@ type EcosystemDiff struct {
 	// and target, its rate is 0.
 	DetectionChangeRate float64
 	KBChangeRate        float64
-	Pass                bool
+
+	// Threshold actually applied to this ecosystem (post override resolution).
+	// ThresholdOverridden is true iff a per-ecosystem override matched.
+	Threshold           float64
+	ThresholdOverridden bool
+
+	Pass bool
 }
 
 // DiffBoltDB compares detection data directly between two BoltDB files.
@@ -134,10 +155,12 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 	defer targetDB.Close()
 
-	results, err := computeDiffs(baselineDB, targetDB, o.changeRateThreshold)
+	results, err := computeDiffs(baselineDB, targetDB, o.changeRateThreshold, o.changeRateThresholdOverrides)
 	if err != nil {
 		return errors.Wrap(err, "compute diffs")
 	}
+
+	warnUnusedOverrides(o.changeRateThresholdOverrides, results)
 
 	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
 	if err != nil {
@@ -145,12 +168,41 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	}
 
 	if !pass {
-		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
+		return errors.Errorf("diff failed: detection and/or KB change rate exceeded threshold (default %.1f%%)", o.changeRateThreshold)
 	}
 	return nil
 }
 
-func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64) ([]EcosystemDiff, error) {
+// resolveThreshold returns the threshold to apply to a given ecosystem,
+// preferring an override entry when present.
+func resolveThreshold(key string, def float64, overrides map[string]float64) (rate float64, overridden bool) {
+	if v, ok := overrides[key]; ok {
+		return v, true
+	}
+	return def, false
+}
+
+// warnUnusedOverrides logs a warning for each override key that did not match
+// any compared ecosystem. Catches typos and stale entries before they silently
+// rot in the workflow file.
+func warnUnusedOverrides(overrides map[string]float64, results []EcosystemDiff) {
+	if len(overrides) == 0 {
+		return
+	}
+	used := make(map[string]bool, len(results))
+	for _, d := range results {
+		if d.ThresholdOverridden {
+			used[string(d.Ecosystem)] = true
+		}
+	}
+	for k := range overrides {
+		if !used[k] {
+			slog.Warn("change-rate-threshold override key did not match any ecosystem", "key", k)
+		}
+	}
+}
+
+func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64, overrides map[string]float64) ([]EcosystemDiff, error) {
 	baselineEcos, err := getEcosystems(baselineDB)
 	if err != nil {
 		return nil, errors.Wrap(err, "get baseline ecosystems")
@@ -174,7 +226,7 @@ func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64) ([
 		g.Go(func() error {
 			slog.Debug("ecosystem diff start", "ecosystem", eco)
 
-			d, err := diffEcosystem(baselineDB, targetDB, eco, changeRateThreshold)
+			d, err := diffEcosystem(baselineDB, targetDB, eco, changeRateThreshold, overrides)
 			if err != nil {
 				return errors.Wrapf(err, "diff ecosystem %s", string(eco))
 			}
@@ -237,7 +289,7 @@ func getEcosystems(db *bolt.DB) ([]ecosystemTypes.Ecosystem, error) {
 
 // diffEcosystem compares an ecosystem between two DBs by diffing each of its
 // sub-buckets (detection, kb) independently. Either sub-bucket may be absent.
-func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem, changeRateThreshold float64) (EcosystemDiff, error) {
+func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosystem, changeRateThreshold float64, overrides map[string]float64) (EcosystemDiff, error) {
 	diff := EcosystemDiff{Ecosystem: ecosystem}
 
 	if err := baselineDB.View(func(btx *bolt.Tx) error {
@@ -275,7 +327,8 @@ func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosy
 
 	diff.DetectionChangeRate = changeRate(diff.BaselineCriterions, diff.TargetCriterions, diff.MatchedCriterions)
 	diff.KBChangeRate = changeRate(diff.BaselineKBs, diff.TargetKBs, diff.MatchedKBs)
-	diff.Pass = diff.DetectionChangeRate <= changeRateThreshold && diff.KBChangeRate <= changeRateThreshold
+	diff.Threshold, diff.ThresholdOverridden = resolveThreshold(string(ecosystem), changeRateThreshold, overrides)
+	diff.Pass = diff.DetectionChangeRate <= diff.Threshold && diff.KBChangeRate <= diff.Threshold
 	return diff, nil
 }
 

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -174,8 +174,9 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 }
 
 // resolveThreshold returns the threshold to apply to a given ecosystem,
-// preferring an override entry when present.
-func resolveThreshold(key string, def float64, overrides map[string]float64) (rate float64, overridden bool) {
+// preferring an override entry when present. The second return value reports
+// whether the override map matched.
+func resolveThreshold(key string, def float64, overrides map[string]float64) (float64, bool) {
 	if v, ok := overrides[key]; ok {
 		return v, true
 	}

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -172,15 +172,6 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 	return nil
 }
 
-// resolveThreshold returns the threshold to apply to a given ecosystem,
-// preferring an override entry when present.
-func resolveThreshold(key string, def float64, overrides map[string]float64) float64 {
-	if v, ok := overrides[key]; ok {
-		return v
-	}
-	return def
-}
-
 func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64, overrides map[string]float64) ([]EcosystemDiff, error) {
 	baselineEcos, err := getEcosystems(baselineDB)
 	if err != nil {
@@ -306,7 +297,12 @@ func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosy
 
 	diff.DetectionChangeRate = changeRate(diff.BaselineCriterions, diff.TargetCriterions, diff.MatchedCriterions)
 	diff.KBChangeRate = changeRate(diff.BaselineKBs, diff.TargetKBs, diff.MatchedKBs)
-	diff.Threshold = resolveThreshold(string(ecosystem), changeRateThreshold, overrides)
+	diff.Threshold = func() float64 {
+		if v, ok := overrides[string(ecosystem)]; ok {
+			return v
+		}
+		return changeRateThreshold
+	}()
 	diff.Pass = diff.DetectionChangeRate <= diff.Threshold && diff.KBChangeRate <= diff.Threshold
 	return diff, nil
 }

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -114,9 +114,7 @@ type EcosystemDiff struct {
 	KBChangeRate        float64
 
 	// Threshold actually applied to this ecosystem (post override resolution).
-	// ThresholdOverridden is true iff a per-ecosystem override matched.
-	Threshold           float64
-	ThresholdOverridden bool
+	Threshold float64
 
 	Pass bool
 }
@@ -160,7 +158,7 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 		return errors.Wrap(err, "compute diffs")
 	}
 
-	pass, err := generateReport(o.writer, results, o.changeRateThreshold)
+	pass, err := generateReport(o.writer, results)
 	if err != nil {
 		return errors.Wrap(err, "generate report")
 	}
@@ -175,13 +173,12 @@ func DiffBoltDB(baselinePath, targetPath string, opts ...Option) error {
 }
 
 // resolveThreshold returns the threshold to apply to a given ecosystem,
-// preferring an override entry when present. The second return value reports
-// whether the override map matched.
-func resolveThreshold(key string, def float64, overrides map[string]float64) (float64, bool) {
+// preferring an override entry when present.
+func resolveThreshold(key string, def float64, overrides map[string]float64) float64 {
 	if v, ok := overrides[key]; ok {
-		return v, true
+		return v
 	}
-	return def, false
+	return def
 }
 
 func computeDiffs(baselineDB, targetDB *bolt.DB, changeRateThreshold float64, overrides map[string]float64) ([]EcosystemDiff, error) {
@@ -309,7 +306,7 @@ func diffEcosystem(baselineDB, targetDB *bolt.DB, ecosystem ecosystemTypes.Ecosy
 
 	diff.DetectionChangeRate = changeRate(diff.BaselineCriterions, diff.TargetCriterions, diff.MatchedCriterions)
 	diff.KBChangeRate = changeRate(diff.BaselineKBs, diff.TargetKBs, diff.MatchedKBs)
-	diff.Threshold, diff.ThresholdOverridden = resolveThreshold(string(ecosystem), changeRateThreshold, overrides)
+	diff.Threshold = resolveThreshold(string(ecosystem), changeRateThreshold, overrides)
 	diff.Pass = diff.DetectionChangeRate <= diff.Threshold && diff.KBChangeRate <= diff.Threshold
 	return diff, nil
 }

--- a/pkg/db/diff/db/db.go
+++ b/pkg/db/diff/db/db.go
@@ -54,8 +54,18 @@ func (o changeRateThresholdOverridesOption) apply(opts *options) {
 // change rate threshold. Keys are ecosystem identifiers (e.g. "ubuntu:26.04");
 // values are percentages. Missing keys fall back to the default supplied via
 // WithChangeRateThreshold. A nil or empty map preserves prior behavior.
+//
+// The provided map is defensively copied; callers may mutate or reuse `m`
+// after this call returns without affecting an in-flight or subsequent diff.
 func WithChangeRateThresholdOverrides(m map[string]float64) Option {
-	return changeRateThresholdOverridesOption(m)
+	if len(m) == 0 {
+		return changeRateThresholdOverridesOption(nil)
+	}
+	cp := make(map[string]float64, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return changeRateThresholdOverridesOption(cp)
 }
 
 type writerOption struct{ w io.Writer }

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -305,7 +305,7 @@ func TestDiffEcosystem(t *testing.T) {
 			}
 			defer tdb.Close()
 
-			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem, 0, nil)
+			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem, 0)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -1003,10 +1003,10 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| ubuntu:22.04 | 75.0% | 0.0% | 10.0% | **FAIL** |
-| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| ubuntu:22.04 | 75.0% | 0.0% |  | **FAIL** |
+| redhat:9 | 0.0% | 0.0% |  | PASS |
 
 ## Detection
 
@@ -1057,9 +1057,9 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| alma:8 | 4.8% | 0.0% | 10.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| alma:8 | 4.8% | 0.0% |  | PASS |
 
 ## Detection
 
@@ -1097,9 +1097,9 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| microsoft | 0.0% | 140.0% | 10.0% | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| microsoft | 0.0% | 140.0% |  | **FAIL** |
 
 ## KB
 
@@ -1160,10 +1160,10 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| alma:8 | 0.0% | 0.0% | 10.0% | PASS |
-| microsoft | 0.0% | 0.0% | 10.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| alma:8 | 0.0% | 0.0% |  | PASS |
+| microsoft | 0.0% | 0.0% |  | PASS |
 
 ## Detection
 
@@ -1215,9 +1215,9 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| mixed:1 | 1.5% | 80.0% | 10.0% | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| mixed:1 | 1.5% | 80.0% |  | **FAIL** |
 
 ## Detection
 
@@ -1243,7 +1243,7 @@ func TestGenerateReport(t *testing.T) {
 `,
 		},
 		{
-			name: "override applied with footnote",
+			name: "override applied",
 			args: args{
 				diffs: []db.EcosystemDiff{
 					{
@@ -1279,12 +1279,10 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
-| ubuntu:26.04 | 40.0% | 0.0% | 50.0%* | PASS |
-| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
-
-` + "`*`" + ` = override applied
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
+| ubuntu:26.04 | 40.0% | 0.0% | 50.0% | PASS |
+| redhat:9 | 0.0% | 0.0% |  | PASS |
 
 ## Detection
 

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -1285,6 +1285,68 @@ func TestGenerateReport(t *testing.T) {
 
 `,
 		},
+		{
+			// Locks the FAIL-first sort tier: a PASS row with a higher rate
+			// (held passing by an override) must still sort below a FAIL row
+			// whose rate is lower. Pure rate-desc sort would put alpha:1 first.
+			name: "FAIL row sorts above higher-rate PASS row",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:           "alpha:1",
+						BaselineKeys:        100,
+						TargetKeys:          100,
+						BaselineCriterions:  500,
+						TargetCriterions:    500,
+						MatchedCriterions:   200,
+						Changed:             []string{"CVE-2026-AAAA"},
+						DetectionChangeRate: 120,
+						Threshold:           150,
+						Pass:                true,
+					},
+					{
+						Ecosystem:           "beta:2",
+						BaselineKeys:        50,
+						TargetKeys:          50,
+						BaselineCriterions:  200,
+						TargetCriterions:    200,
+						MatchedCriterions:   195,
+						Changed:             []string{"CVE-2026-BBBB"},
+						DetectionChangeRate: 5,
+						Threshold:           0,
+						Pass:                false,
+					},
+				},
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: DB
+
+## Summary
+
+**Result**: **FAIL**
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| beta:2 | 5.0% | 0.0% | 0.0% | **FAIL** |
+| alpha:1 | 120.0% | 0.0% | 150.0% | PASS |
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| beta:2 | 50 | 50 | 0 | 0 | 1 | 200 | 200 | 195 |
+| alpha:1 | 100 | 100 | 0 | 0 | 1 | 500 | 500 | 200 |
+
+## Details (FAIL ecosystems)
+
+### beta:2 (5.0%)
+
+#### Changed Root IDs (1)
+
+- CVE-2026-BBBB
+
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -418,6 +418,37 @@ func TestDiffBoltDB(t *testing.T) {
 	}
 }
 
+// TestWithChangeRateThresholdOverridesDefensiveCopy verifies the Option
+// snapshots the caller's map: mutating the original after WithFoo(m) returns
+// must not change subsequent diff behavior.
+func TestWithChangeRateThresholdOverridesDefensiveCopy(t *testing.T) {
+	baselinePath := filepath.Join(t.TempDir(), "vuls.db")
+	if err := populateDB(baselinePath, "testdata/fixtures/baseline"); err != nil {
+		t.Fatal(err)
+	}
+	targetPath := filepath.Join(t.TempDir(), "vuls.db")
+	if err := populateDB(targetPath, "testdata/fixtures/target-replaced"); err != nil {
+		t.Fatal(err)
+	}
+
+	// target-replaced gives alma:8 a 200% detection change rate. With override
+	// {"alma:8": 250} the diff should PASS — and stay PASS even if the caller
+	// later mutates the same map down to a value that would fail.
+	overrides := map[string]float64{"alma:8": 250}
+	opt := db.WithChangeRateThresholdOverrides(overrides)
+	overrides["alma:8"] = 1 // post-Option mutation: must not leak into the Option's snapshot
+
+	gotErr := db.DiffBoltDB(
+		baselinePath, targetPath,
+		db.WithChangeRateThreshold(10),
+		opt,
+		db.WithWriter(&bytes.Buffer{}),
+	)
+	if gotErr != nil {
+		t.Fatalf("DiffBoltDB() returned error %v; expected PASS — caller-side mutation must not affect the Option snapshot", gotErr)
+	}
+}
+
 func TestCompareCriterions(t *testing.T) {
 	type args struct {
 		baseline string

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -381,8 +381,8 @@ func TestDiffBoltDB(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// An override targeting an ecosystem not present in baseline should be
-			// reported (logged) but must not change pass/fail of other ecosystems.
+			// An override targeting an ecosystem not present in baseline must
+			// not change pass/fail of other ecosystems.
 			name: "unmatched override key does not affect outcome",
 			args: args{
 				baselineFixtures:             []string{"testdata/fixtures/baseline"},

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -418,37 +418,6 @@ func TestDiffBoltDB(t *testing.T) {
 	}
 }
 
-// TestWithChangeRateThresholdOverridesDefensiveCopy verifies the Option
-// snapshots the caller's map: mutating the original after WithFoo(m) returns
-// must not change subsequent diff behavior.
-func TestWithChangeRateThresholdOverridesDefensiveCopy(t *testing.T) {
-	baselinePath := filepath.Join(t.TempDir(), "vuls.db")
-	if err := populateDB(baselinePath, "testdata/fixtures/baseline"); err != nil {
-		t.Fatal(err)
-	}
-	targetPath := filepath.Join(t.TempDir(), "vuls.db")
-	if err := populateDB(targetPath, "testdata/fixtures/target-replaced"); err != nil {
-		t.Fatal(err)
-	}
-
-	// target-replaced gives alma:8 a 200% detection change rate. With override
-	// {"alma:8": 250} the diff should PASS — and stay PASS even if the caller
-	// later mutates the same map down to a value that would fail.
-	overrides := map[string]float64{"alma:8": 250}
-	opt := db.WithChangeRateThresholdOverrides(overrides)
-	overrides["alma:8"] = 1 // post-Option mutation: must not leak into the Option's snapshot
-
-	gotErr := db.DiffBoltDB(
-		baselinePath, targetPath,
-		db.WithChangeRateThreshold(10),
-		opt,
-		db.WithWriter(&bytes.Buffer{}),
-	)
-	if gotErr != nil {
-		t.Fatalf("DiffBoltDB() returned error %v; expected PASS — caller-side mutation must not affect the Option snapshot", gotErr)
-	}
-}
-
 func TestCompareCriterions(t *testing.T) {
 	type args struct {
 		baseline string

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -305,7 +305,7 @@ func TestDiffEcosystem(t *testing.T) {
 			}
 			defer tdb.Close()
 
-			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem, 0)
+			got, err := db.DiffEcosystem(bdb, tdb, tt.args.ecosystem, 0, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -319,9 +319,10 @@ func TestDiffEcosystem(t *testing.T) {
 
 func TestDiffBoltDB(t *testing.T) {
 	type args struct {
-		baselineFixtures    []string
-		targetFixtures      []string
-		changeRateThreshold float64
+		baselineFixtures             []string
+		targetFixtures               []string
+		changeRateThreshold          float64
+		changeRateThresholdOverrides map[string]float64
 	}
 	tests := []struct {
 		name    string
@@ -356,6 +357,41 @@ func TestDiffBoltDB(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// target-replaced gives alma:8 a 200% detection change rate; with the
+			// default threshold 10% this normally fails.
+			name: "override lifts ecosystem above threshold",
+			args: args{
+				baselineFixtures:             []string{"testdata/fixtures/baseline"},
+				targetFixtures:               []string{"testdata/fixtures/target-replaced"},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"alma:8": 250},
+			},
+			wantErr: false,
+		},
+		{
+			// Override below the actual rate must still fail.
+			name: "override below rate still fails",
+			args: args{
+				baselineFixtures:             []string{"testdata/fixtures/baseline"},
+				targetFixtures:               []string{"testdata/fixtures/target-replaced"},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"alma:8": 100},
+			},
+			wantErr: true,
+		},
+		{
+			// An override targeting an ecosystem not present in baseline should be
+			// reported (logged) but must not change pass/fail of other ecosystems.
+			name: "unmatched override key does not affect outcome",
+			args: args{
+				baselineFixtures:             []string{"testdata/fixtures/baseline"},
+				targetFixtures:               []string{"testdata/fixtures/target-same"},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"unknown:99": 50},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -371,6 +407,7 @@ func TestDiffBoltDB(t *testing.T) {
 			gotErr := db.DiffBoltDB(
 				baselinePath, targetPath,
 				db.WithChangeRateThreshold(tt.args.changeRateThreshold),
+				db.WithChangeRateThresholdOverrides(tt.args.changeRateThresholdOverrides),
 				db.WithWriter(&bytes.Buffer{}),
 			)
 
@@ -940,6 +977,7 @@ func TestGenerateReport(t *testing.T) {
 						TargetCriterions:    500,
 						MatchedCriterions:   500,
 						DetectionChangeRate: 0,
+						Threshold:           10,
 						Pass:                true,
 					},
 					{
@@ -952,6 +990,7 @@ func TestGenerateReport(t *testing.T) {
 						Removed:             []string{"CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0003"},
 						Changed:             []string{"CVE-2024-0004"},
 						DetectionChangeRate: 75.0,
+						Threshold:           10,
 						Pass:                false,
 					},
 				},
@@ -962,12 +1001,12 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: **FAIL** (Change Rate Threshold: 10.0%)
+**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
-| ubuntu:22.04 | 75.0% | 0.0% | **FAIL** |
-| redhat:9 | 0.0% | 0.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| ubuntu:22.04 | 75.0% | 0.0% | 10.0% | **FAIL** |
+| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1005,6 +1044,7 @@ func TestGenerateReport(t *testing.T) {
 						TargetCriterions:    210,
 						MatchedCriterions:   200,
 						DetectionChangeRate: 4.8,
+						Threshold:           10,
 						Pass:                true,
 					},
 				},
@@ -1015,11 +1055,11 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: PASS (Change Rate Threshold: 10.0%)
+**Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
-| alma:8 | 4.8% | 0.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| alma:8 | 4.8% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1044,6 +1084,7 @@ func TestGenerateReport(t *testing.T) {
 						AddedKBs:       []string{"KB5003"},
 						RemovedKBs:     []string{"KB4000"},
 						KBChangeRate:   140.0,
+						Threshold:      10,
 						Pass:           false,
 					},
 				},
@@ -1054,11 +1095,11 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: **FAIL** (Change Rate Threshold: 10.0%)
+**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
-| microsoft | 0.0% | 140.0% | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| microsoft | 0.0% | 140.0% | 10.0% | **FAIL** |
 
 ## KB
 
@@ -1096,6 +1137,7 @@ func TestGenerateReport(t *testing.T) {
 						BaselineCriterions: 50,
 						TargetCriterions:   50,
 						MatchedCriterions:  50,
+						Threshold:          10,
 						Pass:               true,
 					},
 					{
@@ -1105,6 +1147,7 @@ func TestGenerateReport(t *testing.T) {
 						BaselineKBs:    5,
 						TargetKBs:      5,
 						MatchedKBs:     5,
+						Threshold:      10,
 						Pass:           true,
 					},
 				},
@@ -1115,12 +1158,12 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: PASS (Change Rate Threshold: 10.0%)
+**Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
-| alma:8 | 0.0% | 0.0% | PASS |
-| microsoft | 0.0% | 0.0% | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| alma:8 | 0.0% | 0.0% | 10.0% | PASS |
+| microsoft | 0.0% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1159,6 +1202,7 @@ func TestGenerateReport(t *testing.T) {
 						ChangedKBs:          []string{"KB1", "KB2"},
 						DetectionChangeRate: 1.5,
 						KBChangeRate:        80.0,
+						Threshold:           10,
 						Pass:                false,
 					},
 				},
@@ -1169,11 +1213,11 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: **FAIL** (Change Rate Threshold: 10.0%)
+**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
-| mixed:1 | 1.5% | 80.0% | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| mixed:1 | 1.5% | 80.0% | 10.0% | **FAIL** |
 
 ## Detection
 
@@ -1195,6 +1239,59 @@ func TestGenerateReport(t *testing.T) {
 
 - KB1
 - KB2
+
+`,
+		},
+		{
+			name: "override applied with footnote",
+			args: args{
+				diffs: []db.EcosystemDiff{
+					{
+						Ecosystem:           "ubuntu:26.04",
+						BaselineKeys:        100,
+						TargetKeys:          100,
+						BaselineCriterions:  500,
+						TargetCriterions:    500,
+						MatchedCriterions:   400,
+						Changed:             []string{"CVE-2026-9999"},
+						DetectionChangeRate: 40.0,
+						Threshold:           50,
+						ThresholdOverridden: true,
+						Pass:                true,
+					},
+					{
+						Ecosystem:          "redhat:9",
+						BaselineKeys:       50,
+						TargetKeys:         50,
+						BaselineCriterions: 200,
+						TargetCriterions:   200,
+						MatchedCriterions:  200,
+						Threshold:          10,
+						Pass:               true,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: true,
+			wantReport: `# Diff Report: DB
+
+## Summary
+
+**Result**: PASS (Default Change Rate Threshold: 10.0%)
+
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| ubuntu:26.04 | 40.0% | 0.0% | 50.0%* | PASS |
+| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
+
+` + "`*`" + ` = override applied
+
+## Detection
+
+| Ecosystem | Baseline Keys | Target Keys | Added | Removed | Changed | Baseline Criterions | Target Criterions | Matched Criterions |
+|-----------|---------------|-------------|-------|---------|---------|---------------------|-------------------|--------------------|
+| ubuntu:26.04 | 100 | 100 | 0 | 0 | 1 | 500 | 500 | 400 |
+| redhat:9 | 50 | 50 | 0 | 0 | 0 | 200 | 200 | 200 |
 
 `,
 		},

--- a/pkg/db/diff/db/db_test.go
+++ b/pkg/db/diff/db/db_test.go
@@ -956,8 +956,7 @@ func TestCountKBs(t *testing.T) {
 
 func TestGenerateReport(t *testing.T) {
 	type args struct {
-		diffs               []db.EcosystemDiff
-		changeRateThreshold float64
+		diffs []db.EcosystemDiff
 	}
 	tests := []struct {
 		name       string
@@ -994,19 +993,18 @@ func TestGenerateReport(t *testing.T) {
 						Pass:                false,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
+**Result**: **FAIL**
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-| ubuntu:22.04 | 75.0% | 0.0% |  | **FAIL** |
-| redhat:9 | 0.0% | 0.0% |  | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| ubuntu:22.04 | 75.0% | 0.0% | 10.0% | **FAIL** |
+| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1048,18 +1046,17 @@ func TestGenerateReport(t *testing.T) {
 						Pass:                true,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: true,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: PASS (Default Change Rate Threshold: 10.0%)
+**Result**: PASS
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-| alma:8 | 4.8% | 0.0% |  | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| alma:8 | 4.8% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1088,18 +1085,17 @@ func TestGenerateReport(t *testing.T) {
 						Pass:           false,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
+**Result**: **FAIL**
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-| microsoft | 0.0% | 140.0% |  | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| microsoft | 0.0% | 140.0% | 10.0% | **FAIL** |
 
 ## KB
 
@@ -1151,19 +1147,18 @@ func TestGenerateReport(t *testing.T) {
 						Pass:           true,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: true,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: PASS (Default Change Rate Threshold: 10.0%)
+**Result**: PASS
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-| alma:8 | 0.0% | 0.0% |  | PASS |
-| microsoft | 0.0% | 0.0% |  | PASS |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| alma:8 | 0.0% | 0.0% | 10.0% | PASS |
+| microsoft | 0.0% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1206,18 +1201,17 @@ func TestGenerateReport(t *testing.T) {
 						Pass:                false,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: false,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
+**Result**: **FAIL**
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-| mixed:1 | 1.5% | 80.0% |  | **FAIL** |
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+| mixed:1 | 1.5% | 80.0% | 10.0% | **FAIL** |
 
 ## Detection
 
@@ -1256,7 +1250,6 @@ func TestGenerateReport(t *testing.T) {
 						Changed:             []string{"CVE-2026-9999"},
 						DetectionChangeRate: 40.0,
 						Threshold:           50,
-						ThresholdOverridden: true,
 						Pass:                true,
 					},
 					{
@@ -1270,19 +1263,18 @@ func TestGenerateReport(t *testing.T) {
 						Pass:               true,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: true,
 			wantReport: `# Diff Report: DB
 
 ## Summary
 
-**Result**: PASS (Default Change Rate Threshold: 10.0%)
+**Result**: PASS
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
 | ubuntu:26.04 | 40.0% | 0.0% | 50.0% | PASS |
-| redhat:9 | 0.0% | 0.0% |  | PASS |
+| redhat:9 | 0.0% | 0.0% | 10.0% | PASS |
 
 ## Detection
 
@@ -1297,7 +1289,7 @@ func TestGenerateReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			gotPass, err := db.GenerateReport(&buf, tt.args.diffs, tt.args.changeRateThreshold)
+			gotPass, err := db.GenerateReport(&buf, tt.args.diffs)
 			if err != nil {
 				t.Fatalf("GenerateReport() error = %v", err)
 			}

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -29,7 +29,6 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 	})
 
 	pass := !slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return !r.Pass })
-	anyOverridden := slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return r.ThresholdOverridden })
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: DB
 
@@ -37,8 +36,8 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 
 **Result**: %s (Default Change Rate Threshold: %.1f%%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
-|-----------|-----------------------|----------------|-----------|--------|
+| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
+|-----------|-----------------------|----------------|----------|--------|
 `,
 		resultLabel(pass),
 		changeRateThreshold,
@@ -50,15 +49,10 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 			d.Ecosystem,
 			d.DetectionChangeRate,
 			d.KBChangeRate,
-			thresholdLabel(d.Threshold, d.ThresholdOverridden),
+			overrideLabel(d.Threshold, d.ThresholdOverridden),
 			resultLabel(d.Pass),
 		); err != nil {
 			return false, errors.Wrap(err, "write summary row")
-		}
-	}
-	if anyOverridden {
-		if _, err := fmt.Fprintln(w, "\n`*` = override applied"); err != nil {
-			return false, errors.Wrap(err, "write override footnote")
 		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
@@ -164,13 +158,15 @@ func resultLabel(pass bool) string {
 	return "**FAIL**"
 }
 
-// thresholdLabel renders a threshold value with a trailing "*" when an override
-// was applied, paired with a table footnote (`* = override applied`).
-func thresholdLabel(t float64, overridden bool) string {
+// overrideLabel renders the override threshold (e.g. "25.0%") for rows where
+// an override matched, and an empty cell otherwise. Default-threshold rows
+// stay blank because the default value is already shown in the summary
+// header — duplicating it per-row added noise without useful signal.
+func overrideLabel(t float64, overridden bool) string {
 	if overridden {
-		return fmt.Sprintf("%.1f%%*", t)
+		return fmt.Sprintf("%.1f%%", t)
 	}
-	return fmt.Sprintf("%.1f%%", t)
+	return ""
 }
 
 // boolToInt is a sort helper: false sorts before true, so passing it to

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -16,8 +16,12 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 		return true, errors.New("no ecosystems to compare")
 	}
 
+	// Sort: FAIL first, then by max(rate) desc, then by ecosystem asc.
+	// Per-target threshold can hide a high-rate row behind PASS, so surfacing
+	// FAIL rows first keeps triage focused on what actually blocks promotion.
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
+			cmp.Compare(boolToInt(a.Pass), boolToInt(b.Pass)),
 			-cmp.Compare(max(a.DetectionChangeRate, a.KBChangeRate),
 				max(b.DetectionChangeRate, b.KBChangeRate)),
 			cmp.Compare(a.Ecosystem, b.Ecosystem),
@@ -25,15 +29,16 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 	})
 
 	pass := !slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return !r.Pass })
+	anyOverridden := slices.ContainsFunc(diffs, func(r EcosystemDiff) bool { return r.ThresholdOverridden })
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: DB
 
 ## Summary
 
-**Result**: %s (Change Rate Threshold: %.1f%%)
+**Result**: %s (Default Change Rate Threshold: %.1f%%)
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Result |
-|-----------|-----------------------|----------------|--------|
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
 `,
 		resultLabel(pass),
 		changeRateThreshold,
@@ -41,13 +46,19 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 		return false, errors.Wrap(err, "write header")
 	}
 	for _, d := range diffs {
-		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %s |\n",
+		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %s | %s |\n",
 			d.Ecosystem,
 			d.DetectionChangeRate,
 			d.KBChangeRate,
+			thresholdLabel(d.Threshold, d.ThresholdOverridden),
 			resultLabel(d.Pass),
 		); err != nil {
 			return false, errors.Wrap(err, "write summary row")
+		}
+	}
+	if anyOverridden {
+		if _, err := fmt.Fprintln(w, "\n`*` = override applied"); err != nil {
+			return false, errors.Wrap(err, "write override footnote")
 		}
 	}
 	if _, err := fmt.Fprintln(w); err != nil {
@@ -151,6 +162,24 @@ func resultLabel(pass bool) string {
 		return "PASS"
 	}
 	return "**FAIL**"
+}
+
+// thresholdLabel renders a threshold value with a trailing "*" when an override
+// was applied, paired with a table footnote (`* = override applied`).
+func thresholdLabel(t float64, overridden bool) string {
+	if overridden {
+		return fmt.Sprintf("%.1f%%*", t)
+	}
+	return fmt.Sprintf("%.1f%%", t)
+}
+
+// boolToInt is a sort helper: false sorts before true, so passing it to
+// cmp.Compare(boolToInt(a), boolToInt(b)) puts FAIL rows ahead of PASS rows.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -21,7 +21,16 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 	// FAIL rows first keeps triage focused on what actually blocks promotion.
 	slices.SortFunc(diffs, func(a, b EcosystemDiff) int {
 		return cmp.Or(
-			cmp.Compare(boolToInt(a.Pass), boolToInt(b.Pass)),
+			func() int {
+				switch {
+				case !a.Pass && b.Pass:
+					return -1
+				case a.Pass && !b.Pass:
+					return +1
+				default:
+					return 0
+				}
+			}(),
 			-cmp.Compare(max(a.DetectionChangeRate, a.KBChangeRate),
 				max(b.DetectionChangeRate, b.KBChangeRate)),
 			cmp.Compare(a.Ecosystem, b.Ecosystem),
@@ -167,15 +176,6 @@ func overrideLabel(t float64, overridden bool) string {
 		return fmt.Sprintf("%.1f%%", t)
 	}
 	return ""
-}
-
-// boolToInt is a sort helper: false sorts before true, so passing it to
-// cmp.Compare(boolToInt(a), boolToInt(b)) puts FAIL rows ahead of PASS rows.
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/db/report.go
+++ b/pkg/db/diff/db/report.go
@@ -11,7 +11,7 @@ import (
 
 // generateReport writes a Markdown report for DB diff to w.
 // It returns whether all ecosystems passed and any write error.
-func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold float64) (bool, error) {
+func generateReport(w io.Writer, diffs []EcosystemDiff) (bool, error) {
 	if len(diffs) == 0 {
 		return true, errors.New("no ecosystems to compare")
 	}
@@ -43,22 +43,19 @@ func generateReport(w io.Writer, diffs []EcosystemDiff, changeRateThreshold floa
 
 ## Summary
 
-**Result**: %s (Default Change Rate Threshold: %.1f%%)
+**Result**: %s
 
-| Ecosystem | Detection Change Rate | KB Change Rate | Override | Result |
-|-----------|-----------------------|----------------|----------|--------|
-`,
-		resultLabel(pass),
-		changeRateThreshold,
-	); err != nil {
+| Ecosystem | Detection Change Rate | KB Change Rate | Threshold | Result |
+|-----------|-----------------------|----------------|-----------|--------|
+`, resultLabel(pass)); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 	for _, d := range diffs {
-		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %s | %s |\n",
+		if _, err := fmt.Fprintf(w, "| %s | %.1f%% | %.1f%% | %.1f%% | %s |\n",
 			d.Ecosystem,
 			d.DetectionChangeRate,
 			d.KBChangeRate,
-			overrideLabel(d.Threshold, d.ThresholdOverridden),
+			d.Threshold,
 			resultLabel(d.Pass),
 		); err != nil {
 			return false, errors.Wrap(err, "write summary row")
@@ -165,17 +162,6 @@ func resultLabel(pass bool) string {
 		return "PASS"
 	}
 	return "**FAIL**"
-}
-
-// overrideLabel renders the override threshold (e.g. "25.0%") for rows where
-// an override matched, and an empty cell otherwise. Default-threshold rows
-// stay blank because the default value is already shown in the summary
-// header — duplicating it per-row added noise without useful signal.
-func overrideLabel(t float64, overridden bool) string {
-	if overridden {
-		return fmt.Sprintf("%.1f%%", t)
-	}
-	return ""
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -118,7 +118,16 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 		return errors.Wrap(err, "detect")
 	}
 
-	diffm = computeDiffs(diffm, o.changeRateThreshold, o.changeRateThresholdOverrides)
+	for name, d := range diffm {
+		// Resolve via the canonical map key, not d.Name — the two should
+		// always match in practice but coupling resolution to the key keeps
+		// override lookups consistent across the codebase.
+		threshold := o.changeRateThreshold
+		if v, ok := o.changeRateThresholdOverrides[name]; ok {
+			threshold = v
+		}
+		diffm[name] = diffDetection(d, threshold)
+	}
 
 	pass, err := generateReport(o.writer, diffm)
 	if err != nil {
@@ -314,38 +323,28 @@ skipUpdate = true
 // therefore invisible. This is sufficient for regression detection (missing or
 // extra CVEs), but not for validating data source migrations where IDs stay
 // the same but metadata differs.
-func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64, overrides map[string]float64) map[string]FileDiff {
-	for name, d := range ds {
-		d.Added = subtract(d.TargetIDs, d.BaselineIDs)
-		d.Removed = subtract(d.BaselineIDs, d.TargetIDs)
+// diffDetection fills in the diff fields of a single FileDiff against the
+// supplied resolved threshold. Override resolution is the caller's
+// responsibility. Parallels `diffEcosystem` on the db side.
+func diffDetection(d FileDiff, threshold float64) FileDiff {
+	d.Added = subtract(d.TargetIDs, d.BaselineIDs)
+	d.Removed = subtract(d.BaselineIDs, d.TargetIDs)
 
-		// changeRate can exceed 100% when additions outnumber baseline entries.
-		// This is intentional — capping at 100 would hide the magnitude of large additions.
-		d.ChangeRate = func() float64 {
-			switch {
-			case len(d.BaselineIDs) > 0:
-				return float64(len(d.Added)+len(d.Removed)) / float64(len(d.BaselineIDs)) * 100
-			case len(d.Added)+len(d.Removed) > 0:
-				return 100
-			default:
-				return 0
-			}
-		}()
-		// Resolve via the canonical map key, not d.Name — the two should
-		// always match in practice but coupling resolution to the key keeps
-		// override lookups consistent across the codebase.
-		d.Threshold = func() float64 {
-			if v, ok := overrides[name]; ok {
-				return v
-			}
-			return changeRateThreshold
-		}()
-		d.Pass = d.ChangeRate <= d.Threshold
-
-		ds[name] = d
-	}
-
-	return ds
+	// changeRate can exceed 100% when additions outnumber baseline entries.
+	// This is intentional — capping at 100 would hide the magnitude of large additions.
+	d.ChangeRate = func() float64 {
+		switch {
+		case len(d.BaselineIDs) > 0:
+			return float64(len(d.Added)+len(d.Removed)) / float64(len(d.BaselineIDs)) * 100
+		case len(d.Added)+len(d.Removed) > 0:
+			return 100
+		default:
+			return 0
+		}
+	}()
+	d.Threshold = threshold
+	d.Pass = d.ChangeRate <= threshold
+	return d
 }
 
 // subtract returns elements in a that are not in b (i.e. a \ b).

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -148,15 +148,17 @@ func resolveThreshold(key string, def float64, overrides map[string]float64) (fl
 }
 
 // warnUnusedOverrides logs a warning for each override key that did not match
-// any compared scan-result file. Catches typos / stale entries.
+// any compared scan-result file. Catches typos / stale entries. The "used"
+// set is keyed by the canonical diffm map key rather than FileDiff.Name so
+// the warning is independent of whether callers populate Name consistently.
 func warnUnusedOverrides(overrides map[string]float64, diffm map[string]FileDiff) {
 	if len(overrides) == 0 {
 		return
 	}
 	used := make(map[string]bool, len(diffm))
-	for _, d := range diffm {
+	for name, d := range diffm {
 		if d.ThresholdOverridden {
-			used[d.Name] = true
+			used[name] = true
 		}
 	}
 	for k := range overrides {
@@ -364,7 +366,11 @@ func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64, overrides
 				return 0
 			}
 		}()
-		d.Threshold, d.ThresholdOverridden = resolveThreshold(d.Name, changeRateThreshold, overrides)
+		// Resolve via the canonical map key, not d.Name — the two should
+		// always match in practice but coupling resolution to the key keeps
+		// override lookups consistent with how warnUnusedOverrides reports
+		// "unused" entries.
+		d.Threshold, d.ThresholdOverridden = resolveThreshold(name, changeRateThreshold, overrides)
 		d.Pass = d.ChangeRate <= d.Threshold
 
 		ds[name] = d

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -35,6 +35,7 @@ type changeRateThresholdOption float64
 func (o changeRateThresholdOption) apply(opts *options) {
 	opts.changeRateThreshold = float64(o)
 }
+
 func WithChangeRateThreshold(r float64) Option {
 	return changeRateThresholdOption(r)
 }
@@ -58,6 +59,7 @@ type debugOption bool
 func (o debugOption) apply(opts *options) {
 	opts.debug = bool(o)
 }
+
 func WithDebug(d bool) Option {
 	return debugOption(d)
 }
@@ -67,6 +69,7 @@ type writerOption struct{ w io.Writer }
 func (o writerOption) apply(opts *options) {
 	opts.writer = o.w
 }
+
 func WithWriter(w io.Writer) Option {
 	return writerOption{w: w}
 }

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -19,10 +19,11 @@ import (
 )
 
 type options struct {
-	changeRateThreshold float64
-	debug               bool
-	writer              io.Writer
-	detectFunc          func(baselineBin, baselineDB, targetBin, targetDB string, files map[string]string) (map[string]FileDiff, error)
+	changeRateThreshold          float64
+	changeRateThresholdOverrides map[string]float64
+	debug                        bool
+	writer                       io.Writer
+	detectFunc                   func(baselineBin, baselineDB, targetBin, targetDB string, files map[string]string) (map[string]FileDiff, error)
 }
 
 type Option interface {
@@ -36,6 +37,20 @@ func (o changeRateThresholdOption) apply(opts *options) {
 }
 func WithChangeRateThreshold(r float64) Option {
 	return changeRateThresholdOption(r)
+}
+
+type changeRateThresholdOverridesOption map[string]float64
+
+func (o changeRateThresholdOverridesOption) apply(opts *options) {
+	opts.changeRateThresholdOverrides = map[string]float64(o)
+}
+
+// WithChangeRateThresholdOverrides supplies per-file overrides of the change
+// rate threshold. Keys are scan-result file basenames (without the `.json`
+// extension, e.g. "debian_13"); values are percentages. Missing keys fall
+// back to the default supplied via WithChangeRateThreshold.
+func WithChangeRateThresholdOverrides(m map[string]float64) Option {
+	return changeRateThresholdOverridesOption(m)
 }
 
 type debugOption bool
@@ -64,7 +79,13 @@ type FileDiff struct {
 	Added       []string
 	Removed     []string
 	ChangeRate  float64
-	Pass        bool
+
+	// Threshold actually applied to this file (post override resolution).
+	// ThresholdOverridden is true iff a per-file override matched.
+	Threshold           float64
+	ThresholdOverridden bool
+
+	Pass bool
 }
 
 // Diff compares detection results between baseline and target pairs of (binary, DB).
@@ -99,16 +120,46 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 		return errors.Wrap(err, "detect")
 	}
 
-	diffm = computeDiffs(diffm, o.changeRateThreshold)
+	diffm = computeDiffs(diffm, o.changeRateThreshold, o.changeRateThresholdOverrides)
+
+	warnUnusedOverrides(o.changeRateThresholdOverrides, diffm)
 
 	pass, err := generateReport(o.writer, diffm, o.changeRateThreshold)
 	if err != nil {
 		return errors.Wrap(err, "generate report")
 	}
 	if !pass {
-		return errors.Errorf("diff failed: change rate exceeded threshold (%.1f%%)", o.changeRateThreshold)
+		return errors.Errorf("diff failed: change rate exceeded threshold (default %.1f%%)", o.changeRateThreshold)
 	}
 	return nil
+}
+
+// resolveThreshold returns the threshold to apply to a given file, preferring
+// an override entry when present.
+func resolveThreshold(key string, def float64, overrides map[string]float64) (rate float64, overridden bool) {
+	if v, ok := overrides[key]; ok {
+		return v, true
+	}
+	return def, false
+}
+
+// warnUnusedOverrides logs a warning for each override key that did not match
+// any compared scan-result file. Catches typos / stale entries.
+func warnUnusedOverrides(overrides map[string]float64, diffm map[string]FileDiff) {
+	if len(overrides) == 0 {
+		return
+	}
+	used := make(map[string]bool, len(diffm))
+	for _, d := range diffm {
+		if d.ThresholdOverridden {
+			used[d.Name] = true
+		}
+	}
+	for k := range overrides {
+		if !used[k] {
+			slog.Warn("change-rate-threshold override key did not match any scan-result file", "key", k)
+		}
+	}
 }
 
 // listScanResults lists *.json files in the directory.
@@ -292,7 +343,7 @@ skipUpdate = true
 // therefore invisible. This is sufficient for regression detection (missing or
 // extra CVEs), but not for validating data source migrations where IDs stay
 // the same but metadata differs.
-func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64) map[string]FileDiff {
+func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64, overrides map[string]float64) map[string]FileDiff {
 	for name, d := range ds {
 		d.Added = subtract(d.TargetIDs, d.BaselineIDs)
 		d.Removed = subtract(d.BaselineIDs, d.TargetIDs)
@@ -309,7 +360,8 @@ func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64) map[strin
 				return 0
 			}
 		}()
-		d.Pass = d.ChangeRate <= changeRateThreshold
+		d.Threshold, d.ThresholdOverridden = resolveThreshold(d.Name, changeRateThreshold, overrides)
+		d.Pass = d.ChangeRate <= d.Threshold
 
 		ds[name] = d
 	}

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -49,18 +49,8 @@ func (o changeRateThresholdOverridesOption) apply(opts *options) {
 // rate threshold. Keys are scan-result file basenames (without the `.json`
 // extension, e.g. "debian_13"); values are percentages. Missing keys fall
 // back to the default supplied via WithChangeRateThreshold.
-//
-// The provided map is defensively copied; callers may mutate or reuse `m`
-// after this call returns without affecting an in-flight or subsequent diff.
 func WithChangeRateThresholdOverrides(m map[string]float64) Option {
-	if len(m) == 0 {
-		return changeRateThresholdOverridesOption(nil)
-	}
-	cp := make(map[string]float64, len(m))
-	for k, v := range m {
-		cp[k] = v
-	}
-	return changeRateThresholdOverridesOption(cp)
+	return changeRateThresholdOverridesOption(m)
 }
 
 type debugOption bool

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -125,9 +125,9 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 		return errors.Wrap(err, "generate report")
 	}
 	if !pass {
-		// Resolved per-file threshold (default vs override) is rendered in
-		// the report's Override column, so the exit error stays threshold-free
-		// to avoid implying the default was the one that tripped.
+		// Resolved per-file threshold is rendered per row in the report's
+		// Threshold column, so the exit error stays threshold-free to avoid
+		// implying the default was the one that tripped.
 		return errors.New("diff failed: change rate exceeded the applicable threshold for at least one scan-result file; see report for details")
 	}
 	return nil

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -49,7 +49,8 @@ func (o changeRateThresholdOverridesOption) apply(opts *options) {
 // WithChangeRateThresholdOverrides supplies per-file overrides of the change
 // rate threshold. Keys are scan-result file basenames (without the `.json`
 // extension, e.g. "debian_13"); values are percentages. Missing keys fall
-// back to the default supplied via WithChangeRateThreshold.
+// back to the default supplied via WithChangeRateThreshold. A nil or empty
+// map preserves prior behavior.
 func WithChangeRateThresholdOverrides(m map[string]float64) Option {
 	return changeRateThresholdOverridesOption(m)
 }
@@ -319,16 +320,15 @@ skipUpdate = true
 	return slices.Collect(maps.Keys(sr.ScannedCves)), nil
 }
 
-// computeDiffs computes diffs per file by comparing CVE ID sets.
+// diffDetection fills in the diff fields of a single FileDiff against the
+// supplied resolved threshold. Override resolution is the caller's
+// responsibility. Parallels `diffEcosystem` on the db side.
 //
 // Only CVE IDs are compared; per-CVE content (confidence, affected packages,
 // CVSS, exploit/KEV metadata, etc.) is not diffed. Content-only changes are
 // therefore invisible. This is sufficient for regression detection (missing or
 // extra CVEs), but not for validating data source migrations where IDs stay
 // the same but metadata differs.
-// diffDetection fills in the diff fields of a single FileDiff against the
-// supplied resolved threshold. Override resolution is the caller's
-// responsibility. Parallels `diffEcosystem` on the db side.
 func diffDetection(d FileDiff, threshold float64) FileDiff {
 	d.Added = subtract(d.TargetIDs, d.BaselineIDs)
 	d.Removed = subtract(d.BaselineIDs, d.TargetIDs)

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -122,8 +122,6 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 
 	diffm = computeDiffs(diffm, o.changeRateThreshold, o.changeRateThresholdOverrides)
 
-	warnUnusedOverrides(o.changeRateThresholdOverrides, diffm)
-
 	pass, err := generateReport(o.writer, diffm, o.changeRateThreshold)
 	if err != nil {
 		return errors.Wrap(err, "generate report")
@@ -145,27 +143,6 @@ func resolveThreshold(key string, def float64, overrides map[string]float64) (fl
 		return v, true
 	}
 	return def, false
-}
-
-// warnUnusedOverrides logs a warning for each override key that did not match
-// any compared scan-result file. Catches typos / stale entries. The "used"
-// set is keyed by the canonical diffm map key rather than FileDiff.Name so
-// the warning is independent of whether callers populate Name consistently.
-func warnUnusedOverrides(overrides map[string]float64, diffm map[string]FileDiff) {
-	if len(overrides) == 0 {
-		return
-	}
-	used := make(map[string]bool, len(diffm))
-	for name, d := range diffm {
-		if d.ThresholdOverridden {
-			used[name] = true
-		}
-	}
-	for k := range overrides {
-		if !used[k] {
-			slog.Warn("change-rate-threshold override key did not match any scan-result file", "key", k)
-		}
-	}
 }
 
 // listScanResults lists *.json files in the directory.

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -135,8 +135,9 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 }
 
 // resolveThreshold returns the threshold to apply to a given file, preferring
-// an override entry when present.
-func resolveThreshold(key string, def float64, overrides map[string]float64) (rate float64, overridden bool) {
+// an override entry when present. The second return value reports whether
+// the override map matched.
+func resolveThreshold(key string, def float64, overrides map[string]float64) (float64, bool) {
 	if v, ok := overrides[key]; ok {
 		return v, true
 	}

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -49,8 +49,18 @@ func (o changeRateThresholdOverridesOption) apply(opts *options) {
 // rate threshold. Keys are scan-result file basenames (without the `.json`
 // extension, e.g. "debian_13"); values are percentages. Missing keys fall
 // back to the default supplied via WithChangeRateThreshold.
+//
+// The provided map is defensively copied; callers may mutate or reuse `m`
+// after this call returns without affecting an in-flight or subsequent diff.
 func WithChangeRateThresholdOverrides(m map[string]float64) Option {
-	return changeRateThresholdOverridesOption(m)
+	if len(m) == 0 {
+		return changeRateThresholdOverridesOption(nil)
+	}
+	cp := make(map[string]float64, len(m))
+	for k, v := range m {
+		cp[k] = v
+	}
+	return changeRateThresholdOverridesOption(cp)
 }
 
 type debugOption bool

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -133,15 +133,6 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 	return nil
 }
 
-// resolveThreshold returns the threshold to apply to a given file, preferring
-// an override entry when present.
-func resolveThreshold(key string, def float64, overrides map[string]float64) float64 {
-	if v, ok := overrides[key]; ok {
-		return v
-	}
-	return def
-}
-
 // listScanResults lists *.json files in the directory.
 // Returns a map from file name (without .json extension) to full path.
 func listScanResults(dir string) (map[string]string, error) {
@@ -343,7 +334,12 @@ func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64, overrides
 		// Resolve via the canonical map key, not d.Name — the two should
 		// always match in practice but coupling resolution to the key keeps
 		// override lookups consistent across the codebase.
-		d.Threshold = resolveThreshold(name, changeRateThreshold, overrides)
+		d.Threshold = func() float64 {
+			if v, ok := overrides[name]; ok {
+				return v
+			}
+			return changeRateThreshold
+		}()
 		d.Pass = d.ChangeRate <= d.Threshold
 
 		ds[name] = d

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -129,7 +129,10 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 		return errors.Wrap(err, "generate report")
 	}
 	if !pass {
-		return errors.Errorf("diff failed: change rate exceeded threshold (default %.1f%%)", o.changeRateThreshold)
+		// Resolved per-file threshold (default vs override) is rendered in
+		// the report's Override column, so the exit error stays threshold-free
+		// to avoid implying the default was the one that tripped.
+		return errors.New("diff failed: change rate exceeded the applicable threshold for at least one scan-result file; see report for details")
 	}
 	return nil
 }

--- a/pkg/db/diff/detection/detection.go
+++ b/pkg/db/diff/detection/detection.go
@@ -81,9 +81,7 @@ type FileDiff struct {
 	ChangeRate  float64
 
 	// Threshold actually applied to this file (post override resolution).
-	// ThresholdOverridden is true iff a per-file override matched.
-	Threshold           float64
-	ThresholdOverridden bool
+	Threshold float64
 
 	Pass bool
 }
@@ -122,7 +120,7 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 
 	diffm = computeDiffs(diffm, o.changeRateThreshold, o.changeRateThresholdOverrides)
 
-	pass, err := generateReport(o.writer, diffm, o.changeRateThreshold)
+	pass, err := generateReport(o.writer, diffm)
 	if err != nil {
 		return errors.Wrap(err, "generate report")
 	}
@@ -136,13 +134,12 @@ func Diff(scanResultsDir, baselineDB, baselineBin, targetDB, targetBin string, o
 }
 
 // resolveThreshold returns the threshold to apply to a given file, preferring
-// an override entry when present. The second return value reports whether
-// the override map matched.
-func resolveThreshold(key string, def float64, overrides map[string]float64) (float64, bool) {
+// an override entry when present.
+func resolveThreshold(key string, def float64, overrides map[string]float64) float64 {
 	if v, ok := overrides[key]; ok {
-		return v, true
+		return v
 	}
-	return def, false
+	return def
 }
 
 // listScanResults lists *.json files in the directory.
@@ -345,9 +342,8 @@ func computeDiffs(ds map[string]FileDiff, changeRateThreshold float64, overrides
 		}()
 		// Resolve via the canonical map key, not d.Name — the two should
 		// always match in practice but coupling resolution to the key keeps
-		// override lookups consistent with how warnUnusedOverrides reports
-		// "unused" entries.
-		d.Threshold, d.ThresholdOverridden = resolveThreshold(name, changeRateThreshold, overrides)
+		// override lookups consistent across the codebase.
+		d.Threshold = resolveThreshold(name, changeRateThreshold, overrides)
 		d.Pass = d.ChangeRate <= d.Threshold
 
 		ds[name] = d

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -640,9 +640,10 @@ func TestDiff(t *testing.T) {
 	emptyDir := t.TempDir()
 
 	type args struct {
-		dir                 string
-		detectFunc          detection.DetectFunc
-		changeRateThreshold float64
+		dir                          string
+		detectFunc                   detection.DetectFunc
+		changeRateThreshold          float64
+		changeRateThresholdOverrides map[string]float64
 	}
 	tests := []struct {
 		name    string
@@ -685,12 +686,30 @@ func TestDiff(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			// Locks WithChangeRateThresholdOverrides forwarding from Diff
+			// down to computeDiffs. ubuntu_2204 in fakeDetect produces a
+			// 66.7% change rate (baseline 3 IDs, target 1, two removed),
+			// which would FAIL the 10% default. The "ubuntu_2204=70"
+			// override lifts only that file above its rate so the whole
+			// Diff returns nil. If Diff stops forwarding the option, the
+			// override has no effect and ubuntu_2204 fails again.
+			name: "override forwarded through to per-file resolution",
+			args: args{
+				dir:                          scanDir,
+				detectFunc:                   fakeDetect,
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"ubuntu_2204": 70},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := detection.Diff(
 				tt.args.dir, "baseline.db", "vuls0", "target.db", "vuls0",
 				detection.WithChangeRateThreshold(tt.args.changeRateThreshold),
+				detection.WithChangeRateThresholdOverrides(tt.args.changeRateThresholdOverrides),
 				detection.WithWriter(&bytes.Buffer{}),
 				detection.WithDetectFunc(tt.args.detectFunc),
 			)

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -325,14 +325,13 @@ func TestComputeDiffs(t *testing.T) {
 			},
 			want: map[string]detection.FileDiff{
 				"debian_13": {
-					Name:                "debian_13",
-					BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					Added:               []string{"CVE-2026-0003"},
-					ChangeRate:          50,
-					Threshold:           80,
-					ThresholdOverridden: true,
-					Pass:                true,
+					Name:        "debian_13",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					Added:       []string{"CVE-2026-0003"},
+					ChangeRate:  50,
+					Threshold:   80,
+					Pass:        true,
 				},
 				"redhat_9": {
 					Name:        "redhat_9",
@@ -359,14 +358,13 @@ func TestComputeDiffs(t *testing.T) {
 			},
 			want: map[string]detection.FileDiff{
 				"debian_13": {
-					Name:                "debian_13",
-					BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					Added:               []string{"CVE-2026-0003"},
-					ChangeRate:          50,
-					Threshold:           30,
-					ThresholdOverridden: true,
-					Pass:                false,
+					Name:        "debian_13",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					Added:       []string{"CVE-2026-0003"},
+					ChangeRate:  50,
+					Threshold:   30,
+					Pass:        false,
 				},
 			},
 		},
@@ -384,8 +382,7 @@ func TestComputeDiffs(t *testing.T) {
 
 func TestGenerateReport(t *testing.T) {
 	type args struct {
-		diffs               map[string]detection.FileDiff
-		changeRateThreshold float64
+		diffs map[string]detection.FileDiff
 	}
 	tests := []struct {
 		name       string
@@ -415,19 +412,18 @@ func TestGenerateReport(t *testing.T) {
 						Pass:        false,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: false,
 			wantReport: `# Diff Report: Detection
 
 ## Summary
 
-**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
+**Result**: **FAIL**
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
-|------|----------|--------|-------|---------|-------------|----------|--------|
-| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% |  | **FAIL** |
-| redhat_9 | 2 | 2 | 0 | 0 | 0.0% |  | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% | 10.0% | **FAIL** |
+| redhat_9 | 2 | 2 | 0 | 0 | 0.0% | 10.0% | PASS |
 
 ## Details (FAIL files)
 
@@ -454,18 +450,17 @@ func TestGenerateReport(t *testing.T) {
 						Pass:        true,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: true,
 			wantReport: `# Diff Report: Detection
 
 ## Summary
 
-**Result**: PASS (Default Change Rate Threshold: 10.0%)
+**Result**: PASS
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
-|------|----------|--------|-------|---------|-------------|----------|--------|
-| redhat_9 | 1 | 1 | 0 | 0 | 0.0% |  | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
 
 `,
 		},
@@ -474,14 +469,13 @@ func TestGenerateReport(t *testing.T) {
 			args: args{
 				diffs: map[string]detection.FileDiff{
 					"debian_13": {
-						Name:                "debian_13",
-						BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-						Added:               []string{"CVE-2026-0003"},
-						ChangeRate:          50,
-						Threshold:           80,
-						ThresholdOverridden: true,
-						Pass:                true,
+						Name:        "debian_13",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+						Added:       []string{"CVE-2026-0003"},
+						ChangeRate:  50,
+						Threshold:   80,
+						Pass:        true,
 					},
 					"redhat_9": {
 						Name:        "redhat_9",
@@ -492,19 +486,18 @@ func TestGenerateReport(t *testing.T) {
 						Pass:        true,
 					},
 				},
-				changeRateThreshold: 10,
 			},
 			wantPass: true,
 			wantReport: `# Diff Report: Detection
 
 ## Summary
 
-**Result**: PASS (Default Change Rate Threshold: 10.0%)
+**Result**: PASS
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
-|------|----------|--------|-------|---------|-------------|----------|--------|
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
 | debian_13 | 2 | 3 | 1 | 0 | 50.0% | 80.0% | PASS |
-| redhat_9 | 1 | 1 | 0 | 0 | 0.0% |  | PASS |
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
 
 `,
 		},
@@ -512,7 +505,7 @@ func TestGenerateReport(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			gotPass, err := detection.GenerateReport(&buf, tt.args.diffs, tt.args.changeRateThreshold)
+			gotPass, err := detection.GenerateReport(&buf, tt.args.diffs)
 			if err != nil {
 				t.Fatalf("GenerateReport() error = %v", err)
 			}

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -74,335 +74,168 @@ func TestSubtract(t *testing.T) {
 	}
 }
 
-func TestComputeDiffs(t *testing.T) {
+func TestDiffDetection(t *testing.T) {
 	type args struct {
-		detections                   map[string]detection.FileDiff
-		changeRateThreshold          float64
-		changeRateThresholdOverrides map[string]float64
+		d         detection.FileDiff
+		threshold float64
 	}
 	tests := []struct {
 		name string
 		args args
-		want map[string]detection.FileDiff
+		want detection.FileDiff
 	}{
 		{
 			name: "no change",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
+				d: detection.FileDiff{
 					Name:        "redhat_9",
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
 				},
+				threshold: 10,
+			},
+			want: detection.FileDiff{
+				Name:        "redhat_9",
+				BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+				TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+				ChangeRate:  0,
+				Threshold:   10,
+				Pass:        true,
 			},
 		},
 		{
 			name: "small change within limit",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name: "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
-							"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0010"},
-						TargetIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
-							"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0011"},
-					},
-				},
-				changeRateThreshold: 25,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
+				d: detection.FileDiff{
 					Name: "redhat_9",
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
 						"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0010"},
 					TargetIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
 						"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0011"},
-					Added:      []string{"CVE-2026-0011"},
-					Removed:    []string{"CVE-2026-0010"},
-					ChangeRate: 20,
-					Threshold:  25,
-					Pass:       true,
 				},
+				threshold: 25,
+			},
+			want: detection.FileDiff{
+				Name: "redhat_9",
+				BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+					"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0010"},
+				TargetIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005",
+					"CVE-2026-0006", "CVE-2026-0007", "CVE-2026-0008", "CVE-2026-0009", "CVE-2026-0011"},
+				Added:      []string{"CVE-2026-0011"},
+				Removed:    []string{"CVE-2026-0010"},
+				ChangeRate: 20,
+				Threshold:  25,
+				Pass:       true,
 			},
 		},
 		{
-			name: "large change exceeds limit",
+			name: "large removal exceeds limit",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"ubuntu_22.04": {
-						Name:        "ubuntu_22.04",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
-						TargetIDs:   []string{"CVE-2026-0001"},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"ubuntu_22.04": {
+				d: detection.FileDiff{
 					Name:        "ubuntu_22.04",
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
 					TargetIDs:   []string{"CVE-2026-0001"},
-					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
-					ChangeRate:  75,
-					Threshold:   10,
-					Pass:        false,
 				},
+				threshold: 10,
+			},
+			want: detection.FileDiff{
+				Name:        "ubuntu_22.04",
+				BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+				TargetIDs:   []string{"CVE-2026-0001"},
+				Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
+				ChangeRate:  75,
+				Threshold:   10,
+				Pass:        false,
 			},
 		},
 		{
 			name: "large addition exceeds limit",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"ubuntu_22.04": {
-						Name:        "ubuntu_22.04",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"ubuntu_22.04": {
+				d: detection.FileDiff{
 					Name:        "ubuntu_22.04",
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
-					Added:       []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
-					ChangeRate:  200,
-					Threshold:   10,
-					Pass:        false,
 				},
+				threshold: 10,
+			},
+			want: detection.FileDiff{
+				Name:        "ubuntu_22.04",
+				BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+				TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
+				Added:       []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
+				ChangeRate:  200,
+				Threshold:   10,
+				Pass:        false,
 			},
 		},
 		{
 			name: "empty baseline triggers 100% change",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
+				d: detection.FileDiff{
 					Name:        "redhat_9",
 					BaselineIDs: []string{},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					Added:       []string{"CVE-2026-0001", "CVE-2026-0002"},
-					ChangeRate:  100,
-					Threshold:   10,
-					Pass:        false,
 				},
+				threshold: 10,
+			},
+			want: detection.FileDiff{
+				Name:        "redhat_9",
+				BaselineIDs: []string{},
+				TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+				Added:       []string{"CVE-2026-0001", "CVE-2026-0002"},
+				ChangeRate:  100,
+				Threshold:   10,
+				Pass:        false,
 			},
 		},
 		{
 			name: "both empty avoids zero division",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{},
-						TargetIDs:   []string{},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
+				d: detection.FileDiff{
 					Name:        "redhat_9",
 					BaselineIDs: []string{},
 					TargetIDs:   []string{},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
 				},
+				threshold: 10,
+			},
+			want: detection.FileDiff{
+				Name:        "redhat_9",
+				BaselineIDs: []string{},
+				TargetIDs:   []string{},
+				ChangeRate:  0,
+				Threshold:   10,
+				Pass:        true,
 			},
 		},
 		{
-			name: "target all removed",
+			// Caller-resolved override-style threshold (higher than default)
+			// is applied verbatim and lifts the row above its rate.
+			name: "high threshold lets a moderate rate pass",
 			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					},
-					"ubuntu_22.04": {
-						Name:        "ubuntu_22.04",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-						TargetIDs:   nil,
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
-					Name:        "redhat_9",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
-				},
-				"ubuntu_22.04": {
-					Name:        "ubuntu_22.04",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					Removed:     []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					ChangeRate:  100,
-					Threshold:   10,
-					Pass:        false,
-				},
-			},
-		},
-		{
-			name: "multiple files mixed",
-			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					},
-					"ubuntu_22.04": {
-						Name:        "ubuntu_22.04",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
-						TargetIDs:   []string{"CVE-2026-0001"},
-					},
-				},
-				changeRateThreshold: 10,
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
-					Name:        "redhat_9",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
-				},
-				"ubuntu_22.04": {
-					Name:        "ubuntu_22.04",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
-					TargetIDs:   []string{"CVE-2026-0001"},
-					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
-					ChangeRate:  75,
-					Threshold:   10,
-					Pass:        false,
-				},
-			},
-		},
-		{
-			name: "override lifts a single file above default threshold",
-			args: args{
-				detections: map[string]detection.FileDiff{
-					"debian_13": {
-						Name:        "debian_13",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					},
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001"},
-						TargetIDs:   []string{"CVE-2026-0001"},
-					},
-				},
-				changeRateThreshold:          10,
-				changeRateThresholdOverrides: map[string]float64{"debian_13": 80},
-			},
-			want: map[string]detection.FileDiff{
-				"debian_13": {
+				d: detection.FileDiff{
 					Name:        "debian_13",
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					Added:       []string{"CVE-2026-0003"},
-					ChangeRate:  50,
-					Threshold:   80,
-					Pass:        true,
 				},
-				"redhat_9": {
-					Name:        "redhat_9",
-					BaselineIDs: []string{"CVE-2026-0001"},
-					TargetIDs:   []string{"CVE-2026-0001"},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
-				},
+				threshold: 80,
 			},
-		},
-		{
-			name: "override below rate still fails",
-			args: args{
-				detections: map[string]detection.FileDiff{
-					"debian_13": {
-						Name:        "debian_13",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					},
-				},
-				changeRateThreshold:          10,
-				changeRateThresholdOverrides: map[string]float64{"debian_13": 30},
-			},
-			want: map[string]detection.FileDiff{
-				"debian_13": {
-					Name:        "debian_13",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
-					Added:       []string{"CVE-2026-0003"},
-					ChangeRate:  50,
-					Threshold:   30,
-					Pass:        false,
-				},
-			},
-		},
-		{
-			// An override key that matches no file in the diffm must fall
-			// through cleanly: every file still resolves to the default
-			// threshold and pass/fail is unchanged. Locks the
-			// `if v, ok := overrides[name]; ok` miss branch in computeDiffs.
-			name: "unmatched override key does not affect outcome",
-			args: args{
-				detections: map[string]detection.FileDiff{
-					"redhat_9": {
-						Name:        "redhat_9",
-						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					},
-				},
-				changeRateThreshold:          10,
-				changeRateThresholdOverrides: map[string]float64{"unknown_99": 50},
-			},
-			want: map[string]detection.FileDiff{
-				"redhat_9": {
-					Name:        "redhat_9",
-					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
-					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
-					ChangeRate:  0,
-					Threshold:   10,
-					Pass:        true,
-				},
+			want: detection.FileDiff{
+				Name:        "debian_13",
+				BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+				TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+				Added:       []string{"CVE-2026-0003"},
+				ChangeRate:  50,
+				Threshold:   80,
+				Pass:        true,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detection.ComputeDiffs(tt.args.detections, tt.args.changeRateThreshold, tt.args.changeRateThresholdOverrides)
+			got := detection.DiffDetection(tt.args.d, tt.args.threshold)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ComputeDiffs() mismatch (-want +got):\n%s", diff)
+				t.Errorf("DiffDetection() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -687,19 +520,33 @@ func TestDiff(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// Locks WithChangeRateThresholdOverrides forwarding from Diff
-			// down to computeDiffs. ubuntu_2204 in fakeDetect produces a
-			// 66.7% change rate (baseline 3 IDs, target 1, two removed),
-			// which would FAIL the 10% default. The "ubuntu_2204=70"
-			// override lifts only that file above its rate so the whole
-			// Diff returns nil. If Diff stops forwarding the option, the
-			// override has no effect and ubuntu_2204 fails again.
+			// Locks WithChangeRateThresholdOverrides forwarding through the
+			// inline resolve+diffDetection loop in Diff. ubuntu_2204 in
+			// fakeDetect produces a 66.7% change rate (baseline 3 IDs,
+			// target 1, two removed) which would FAIL the 10% default. The
+			// "ubuntu_2204=70" override lifts only that file above its rate
+			// so the whole Diff returns nil. If Diff stops forwarding the
+			// option, the override has no effect and ubuntu_2204 fails again.
 			name: "override forwarded through to per-file resolution",
 			args: args{
 				dir:                          scanDir,
 				detectFunc:                   fakeDetect,
 				changeRateThreshold:          10,
 				changeRateThresholdOverrides: map[string]float64{"ubuntu_2204": 70},
+			},
+			wantErr: false,
+		},
+		{
+			// An override entry that matches no file in the diffm must fall
+			// through cleanly: every file still resolves to the default
+			// threshold. Locks the `if v, ok := overrides[name]; ok` miss
+			// branch in Diff's inline resolve loop.
+			name: "unmatched override key does not affect outcome",
+			args: args{
+				dir:                          scanDir,
+				detectFunc:                   fakeDetect,
+				changeRateThreshold:          100, // both files pass at default
+				changeRateThresholdOverrides: map[string]float64{"unknown_99": 1},
 			},
 			wantErr: false,
 		},

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -368,6 +368,34 @@ func TestComputeDiffs(t *testing.T) {
 				},
 			},
 		},
+		{
+			// An override key that matches no file in the diffm must fall
+			// through cleanly: every file still resolves to the default
+			// threshold and pass/fail is unchanged. Locks the
+			// `if v, ok := overrides[name]; ok` miss branch in computeDiffs.
+			name: "unmatched override key does not affect outcome",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					},
+				},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"unknown_99": 50},
+			},
+			want: map[string]detection.FileDiff{
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
+					ChangeRate:  0,
+					Threshold:   10,
+					Pass:        true,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -498,6 +526,61 @@ func TestGenerateReport(t *testing.T) {
 |------|----------|--------|-------|---------|-------------|-----------|--------|
 | debian_13 | 2 | 3 | 1 | 0 | 50.0% | 80.0% | PASS |
 | redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
+
+`,
+		},
+		{
+			// Locks the FAIL-first sort tier: a PASS row with a higher change
+			// rate (held passing by an override) must sort below a FAIL row
+			// whose rate is lower. Pure rate-desc sort would put alpha first.
+			name: "FAIL row sorts above higher-rate PASS row",
+			args: args{
+				diffs: map[string]detection.FileDiff{
+					"alpha": {
+						Name:        "alpha",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005"},
+						Added:       []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005"},
+						Removed:     []string{"CVE-2026-0001", "CVE-2026-0002"},
+						ChangeRate:  250,
+						Threshold:   300,
+						Pass:        true,
+					},
+					"beta": {
+						Name:        "beta",
+						BaselineIDs: []string{"CVE-2026-1001", "CVE-2026-1002"},
+						TargetIDs:   []string{"CVE-2026-1001", "CVE-2026-1003"},
+						Added:       []string{"CVE-2026-1003"},
+						Removed:     []string{"CVE-2026-1002"},
+						ChangeRate:  100,
+						Threshold:   0,
+						Pass:        false,
+					},
+				},
+			},
+			wantPass: false,
+			wantReport: `# Diff Report: Detection
+
+## Summary
+
+**Result**: **FAIL**
+
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| beta | 2 | 2 | 1 | 1 | 100.0% | 0.0% | **FAIL** |
+| alpha | 2 | 3 | 3 | 2 | 250.0% | 300.0% | PASS |
+
+## Details (FAIL files)
+
+### beta (100.0%)
+
+#### Added IDs (1)
+
+- CVE-2026-1003
+
+#### Removed IDs (1)
+
+- CVE-2026-1002
 
 `,
 		},

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -424,10 +424,10 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
-|------|----------|--------|-------|---------|-------------|-----------|--------|
-| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% | 10.0% | **FAIL** |
-| redhat_9 | 2 | 2 | 0 | 0 | 0.0% | 10.0% | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
+|------|----------|--------|-------|---------|-------------|----------|--------|
+| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% |  | **FAIL** |
+| redhat_9 | 2 | 2 | 0 | 0 | 0.0% |  | PASS |
 
 ## Details (FAIL files)
 
@@ -463,14 +463,14 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
-|------|----------|--------|-------|---------|-------------|-----------|--------|
-| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
+|------|----------|--------|-------|---------|-------------|----------|--------|
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% |  | PASS |
 
 `,
 		},
 		{
-			name: "override applied with footnote",
+			name: "override applied",
 			args: args{
 				diffs: map[string]detection.FileDiff{
 					"debian_13": {
@@ -501,12 +501,10 @@ func TestGenerateReport(t *testing.T) {
 
 **Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
-|------|----------|--------|-------|---------|-------------|-----------|--------|
-| debian_13 | 2 | 3 | 1 | 0 | 50.0% | 80.0%* | PASS |
-| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
-
-` + "`*`" + ` = override applied
+| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
+|------|----------|--------|-------|---------|-------------|----------|--------|
+| debian_13 | 2 | 3 | 1 | 0 | 50.0% | 80.0% | PASS |
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% |  | PASS |
 
 `,
 		},

--- a/pkg/db/diff/detection/detection_test.go
+++ b/pkg/db/diff/detection/detection_test.go
@@ -76,8 +76,9 @@ func TestSubtract(t *testing.T) {
 
 func TestComputeDiffs(t *testing.T) {
 	type args struct {
-		detections          map[string]detection.FileDiff
-		changeRateThreshold float64
+		detections                   map[string]detection.FileDiff
+		changeRateThreshold          float64
+		changeRateThresholdOverrides map[string]float64
 	}
 	tests := []struct {
 		name string
@@ -102,6 +103,7 @@ func TestComputeDiffs(t *testing.T) {
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
 					ChangeRate:  0,
+					Threshold:   10,
 					Pass:        true,
 				},
 			},
@@ -130,6 +132,7 @@ func TestComputeDiffs(t *testing.T) {
 					Added:      []string{"CVE-2026-0011"},
 					Removed:    []string{"CVE-2026-0010"},
 					ChangeRate: 20,
+					Threshold:  25,
 					Pass:       true,
 				},
 			},
@@ -153,6 +156,7 @@ func TestComputeDiffs(t *testing.T) {
 					TargetIDs:   []string{"CVE-2026-0001"},
 					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
 					ChangeRate:  75,
+					Threshold:   10,
 					Pass:        false,
 				},
 			},
@@ -176,6 +180,7 @@ func TestComputeDiffs(t *testing.T) {
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
 					Added:       []string{"CVE-2026-0003", "CVE-2026-0004", "CVE-2026-0005", "CVE-2026-0006"},
 					ChangeRate:  200,
+					Threshold:   10,
 					Pass:        false,
 				},
 			},
@@ -199,6 +204,7 @@ func TestComputeDiffs(t *testing.T) {
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
 					Added:       []string{"CVE-2026-0001", "CVE-2026-0002"},
 					ChangeRate:  100,
+					Threshold:   10,
 					Pass:        false,
 				},
 			},
@@ -221,6 +227,7 @@ func TestComputeDiffs(t *testing.T) {
 					BaselineIDs: []string{},
 					TargetIDs:   []string{},
 					ChangeRate:  0,
+					Threshold:   10,
 					Pass:        true,
 				},
 			},
@@ -248,6 +255,7 @@ func TestComputeDiffs(t *testing.T) {
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
 					ChangeRate:  0,
+					Threshold:   10,
 					Pass:        true,
 				},
 				"ubuntu_22.04": {
@@ -255,6 +263,7 @@ func TestComputeDiffs(t *testing.T) {
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
 					Removed:     []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
 					ChangeRate:  100,
+					Threshold:   10,
 					Pass:        false,
 				},
 			},
@@ -282,6 +291,7 @@ func TestComputeDiffs(t *testing.T) {
 					BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 					TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
 					ChangeRate:  0,
+					Threshold:   10,
 					Pass:        true,
 				},
 				"ubuntu_22.04": {
@@ -290,7 +300,73 @@ func TestComputeDiffs(t *testing.T) {
 					TargetIDs:   []string{"CVE-2026-0001"},
 					Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
 					ChangeRate:  75,
+					Threshold:   10,
 					Pass:        false,
+				},
+			},
+		},
+		{
+			name: "override lifts a single file above default threshold",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"debian_13": {
+						Name:        "debian_13",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					},
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+					},
+				},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"debian_13": 80},
+			},
+			want: map[string]detection.FileDiff{
+				"debian_13": {
+					Name:                "debian_13",
+					BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					Added:               []string{"CVE-2026-0003"},
+					ChangeRate:          50,
+					Threshold:           80,
+					ThresholdOverridden: true,
+					Pass:                true,
+				},
+				"redhat_9": {
+					Name:        "redhat_9",
+					BaselineIDs: []string{"CVE-2026-0001"},
+					TargetIDs:   []string{"CVE-2026-0001"},
+					ChangeRate:  0,
+					Threshold:   10,
+					Pass:        true,
+				},
+			},
+		},
+		{
+			name: "override below rate still fails",
+			args: args{
+				detections: map[string]detection.FileDiff{
+					"debian_13": {
+						Name:        "debian_13",
+						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					},
+				},
+				changeRateThreshold:          10,
+				changeRateThresholdOverrides: map[string]float64{"debian_13": 30},
+			},
+			want: map[string]detection.FileDiff{
+				"debian_13": {
+					Name:                "debian_13",
+					BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
+					TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+					Added:               []string{"CVE-2026-0003"},
+					ChangeRate:          50,
+					Threshold:           30,
+					ThresholdOverridden: true,
+					Pass:                false,
 				},
 			},
 		},
@@ -298,7 +374,7 @@ func TestComputeDiffs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := detection.ComputeDiffs(tt.args.detections, tt.args.changeRateThreshold)
+			got := detection.ComputeDiffs(tt.args.detections, tt.args.changeRateThreshold, tt.args.changeRateThresholdOverrides)
 			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("ComputeDiffs() mismatch (-want +got):\n%s", diff)
 			}
@@ -326,6 +402,7 @@ func TestGenerateReport(t *testing.T) {
 						BaselineIDs: []string{"CVE-2026-0001", "CVE-2026-0002"},
 						TargetIDs:   []string{"CVE-2026-0001", "CVE-2026-0002"},
 						ChangeRate:  0,
+						Threshold:   10,
 						Pass:        true,
 					},
 					"ubuntu_22.04": {
@@ -334,6 +411,7 @@ func TestGenerateReport(t *testing.T) {
 						TargetIDs:   []string{"CVE-2026-0001"},
 						Removed:     []string{"CVE-2026-0002", "CVE-2026-0003", "CVE-2026-0004"},
 						ChangeRate:  75.0,
+						Threshold:   10,
 						Pass:        false,
 					},
 				},
@@ -344,12 +422,12 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: **FAIL** (Change Rate Threshold: 10.0%)
+**Result**: **FAIL** (Default Change Rate Threshold: 10.0%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Result |
-|------|----------|--------|-------|---------|-------------|--------|
-| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% | **FAIL** |
-| redhat_9 | 2 | 2 | 0 | 0 | 0.0% | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| ubuntu_22.04 | 4 | 1 | 0 | 3 | 75.0% | 10.0% | **FAIL** |
+| redhat_9 | 2 | 2 | 0 | 0 | 0.0% | 10.0% | PASS |
 
 ## Details (FAIL files)
 
@@ -372,6 +450,7 @@ func TestGenerateReport(t *testing.T) {
 						BaselineIDs: []string{"CVE-2026-0001"},
 						TargetIDs:   []string{"CVE-2026-0001"},
 						ChangeRate:  0,
+						Threshold:   10,
 						Pass:        true,
 					},
 				},
@@ -382,11 +461,52 @@ func TestGenerateReport(t *testing.T) {
 
 ## Summary
 
-**Result**: PASS (Change Rate Threshold: 10.0%)
+**Result**: PASS (Default Change Rate Threshold: 10.0%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Result |
-|------|----------|--------|-------|---------|-------------|--------|
-| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | PASS |
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
+
+`,
+		},
+		{
+			name: "override applied with footnote",
+			args: args{
+				diffs: map[string]detection.FileDiff{
+					"debian_13": {
+						Name:                "debian_13",
+						BaselineIDs:         []string{"CVE-2026-0001", "CVE-2026-0002"},
+						TargetIDs:           []string{"CVE-2026-0001", "CVE-2026-0002", "CVE-2026-0003"},
+						Added:               []string{"CVE-2026-0003"},
+						ChangeRate:          50,
+						Threshold:           80,
+						ThresholdOverridden: true,
+						Pass:                true,
+					},
+					"redhat_9": {
+						Name:        "redhat_9",
+						BaselineIDs: []string{"CVE-2026-0001"},
+						TargetIDs:   []string{"CVE-2026-0001"},
+						ChangeRate:  0,
+						Threshold:   10,
+						Pass:        true,
+					},
+				},
+				changeRateThreshold: 10,
+			},
+			wantPass: true,
+			wantReport: `# Diff Report: Detection
+
+## Summary
+
+**Result**: PASS (Default Change Rate Threshold: 10.0%)
+
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+| debian_13 | 2 | 3 | 1 | 0 | 50.0% | 80.0%* | PASS |
+| redhat_9 | 1 | 1 | 0 | 0 | 0.0% | 10.0% | PASS |
+
+` + "`*`" + ` = override applied
 
 `,
 		},

--- a/pkg/db/diff/detection/export_test.go
+++ b/pkg/db/diff/detection/export_test.go
@@ -14,6 +14,6 @@ func (o detectFuncOption) apply(opts *options) {
 
 var (
 	Subtract       = subtract
-	ComputeDiffs   = computeDiffs
+	DiffDetection  = diffDetection
 	GenerateReport = generateReport
 )

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -12,7 +12,7 @@ import (
 
 // generateReport writes a Markdown report for detection diff to w.
 // It returns whether all files passed and any write error.
-func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold float64) (bool, error) {
+func generateReport(w io.Writer, diffm map[string]FileDiff) (bool, error) {
 	if len(diffm) == 0 {
 		return true, errors.New("no files to compare")
 	}
@@ -43,18 +43,18 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 ## Summary
 
-**Result**: %s (Default Change Rate Threshold: %.1f%%)
+**Result**: %s
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
-|------|----------|--------|-------|---------|-------------|----------|--------|
-`, resultLabel(pass), changeRateThreshold); err != nil {
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
+`, resultLabel(pass)); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 
 	for _, d := range diffs {
-		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s | %s |\n",
+		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %.1f%% | %s |\n",
 			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate,
-			overrideLabel(d.Threshold, d.ThresholdOverridden), resultLabel(d.Pass)); err != nil {
+			d.Threshold, resultLabel(d.Pass)); err != nil {
 			return false, errors.Wrap(err, "write summary row")
 		}
 	}
@@ -102,17 +102,6 @@ func resultLabel(pass bool) string {
 		return "PASS"
 	}
 	return "**FAIL**"
-}
-
-// overrideLabel renders the override threshold (e.g. "25.0%") for rows where
-// an override matched, and an empty cell otherwise. Default-threshold rows
-// stay blank because the default value is already shown in the summary
-// header — duplicating it per-row added noise without useful signal.
-func overrideLabel(t float64, overridden bool) string {
-	if overridden {
-		return fmt.Sprintf("%.1f%%", t)
-	}
-	return ""
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -23,7 +23,16 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	// FAIL rows first keeps triage focused on what actually blocks promotion.
 	slices.SortFunc(diffs, func(a, b FileDiff) int {
 		return cmp.Or(
-			cmp.Compare(boolToInt(a.Pass), boolToInt(b.Pass)),
+			func() int {
+				switch {
+				case !a.Pass && b.Pass:
+					return -1
+				case a.Pass && !b.Pass:
+					return +1
+				default:
+					return 0
+				}
+			}(),
 			cmp.Compare(b.ChangeRate, a.ChangeRate),
 			cmp.Compare(a.Name, b.Name),
 		)
@@ -104,15 +113,6 @@ func overrideLabel(t float64, overridden bool) string {
 		return fmt.Sprintf("%.1f%%", t)
 	}
 	return ""
-}
-
-// boolToInt is a sort helper: false sorts before true, so passing it to
-// cmp.Compare(boolToInt(a), boolToInt(b)) puts FAIL rows ahead of PASS rows.
-func boolToInt(b bool) int {
-	if b {
-		return 1
-	}
-	return 0
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -29,7 +29,6 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 		)
 	})
 	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
-	anyOverridden := slices.ContainsFunc(diffs, func(d FileDiff) bool { return d.ThresholdOverridden })
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
 
@@ -37,8 +36,8 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 
 **Result**: %s (Default Change Rate Threshold: %.1f%%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
-|------|----------|--------|-------|---------|-------------|-----------|--------|
+| Name | Baseline | Target | Added | Removed | Change Rate | Override | Result |
+|------|----------|--------|-------|---------|-------------|----------|--------|
 `, resultLabel(pass), changeRateThreshold); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
@@ -46,16 +45,11 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	for _, d := range diffs {
 		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s | %s |\n",
 			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate,
-			thresholdLabel(d.Threshold, d.ThresholdOverridden), resultLabel(d.Pass)); err != nil {
+			overrideLabel(d.Threshold, d.ThresholdOverridden), resultLabel(d.Pass)); err != nil {
 			return false, errors.Wrap(err, "write summary row")
 		}
 	}
 
-	if anyOverridden {
-		if _, err := fmt.Fprintln(w, "\n`*` = override applied"); err != nil {
-			return false, errors.Wrap(err, "write override footnote")
-		}
-	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return false, errors.Wrap(err, "write separator")
 	}
@@ -101,13 +95,15 @@ func resultLabel(pass bool) string {
 	return "**FAIL**"
 }
 
-// thresholdLabel renders a threshold value with a trailing "*" when an override
-// was applied, paired with a table footnote (`* = override applied`).
-func thresholdLabel(t float64, overridden bool) string {
+// overrideLabel renders the override threshold (e.g. "25.0%") for rows where
+// an override matched, and an empty cell otherwise. Default-threshold rows
+// stay blank because the default value is already shown in the summary
+// header — duplicating it per-row added noise without useful signal.
+func overrideLabel(t float64, overridden bool) string {
 	if overridden {
-		return fmt.Sprintf("%.1f%%*", t)
+		return fmt.Sprintf("%.1f%%", t)
 	}
-	return fmt.Sprintf("%.1f%%", t)
+	return ""
 }
 
 // boolToInt is a sort helper: false sorts before true, so passing it to

--- a/pkg/db/diff/detection/report.go
+++ b/pkg/db/diff/detection/report.go
@@ -18,33 +18,44 @@ func generateReport(w io.Writer, diffm map[string]FileDiff, changeRateThreshold 
 	}
 
 	diffs := slices.Collect(maps.Values(diffm))
+	// Sort: FAIL first, then by rate desc, then by name asc.
+	// Per-target threshold can hide a high-rate row behind PASS, so surfacing
+	// FAIL rows first keeps triage focused on what actually blocks promotion.
 	slices.SortFunc(diffs, func(a, b FileDiff) int {
 		return cmp.Or(
+			cmp.Compare(boolToInt(a.Pass), boolToInt(b.Pass)),
 			cmp.Compare(b.ChangeRate, a.ChangeRate),
 			cmp.Compare(a.Name, b.Name),
 		)
 	})
 	pass := !slices.ContainsFunc(diffs, func(d FileDiff) bool { return !d.Pass })
+	anyOverridden := slices.ContainsFunc(diffs, func(d FileDiff) bool { return d.ThresholdOverridden })
 
 	if _, err := fmt.Fprintf(w, `# Diff Report: Detection
 
 ## Summary
 
-**Result**: %s (Change Rate Threshold: %.1f%%)
+**Result**: %s (Default Change Rate Threshold: %.1f%%)
 
-| Name | Baseline | Target | Added | Removed | Change Rate | Result |
-|------|----------|--------|-------|---------|-------------|--------|
+| Name | Baseline | Target | Added | Removed | Change Rate | Threshold | Result |
+|------|----------|--------|-------|---------|-------------|-----------|--------|
 `, resultLabel(pass), changeRateThreshold); err != nil {
 		return false, errors.Wrap(err, "write header")
 	}
 
 	for _, d := range diffs {
-		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s |\n",
-			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate, resultLabel(d.Pass)); err != nil {
+		if _, err := fmt.Fprintf(w, "| %s | %d | %d | %d | %d | %.1f%% | %s | %s |\n",
+			d.Name, len(d.BaselineIDs), len(d.TargetIDs), len(d.Added), len(d.Removed), d.ChangeRate,
+			thresholdLabel(d.Threshold, d.ThresholdOverridden), resultLabel(d.Pass)); err != nil {
 			return false, errors.Wrap(err, "write summary row")
 		}
 	}
 
+	if anyOverridden {
+		if _, err := fmt.Fprintln(w, "\n`*` = override applied"); err != nil {
+			return false, errors.Wrap(err, "write override footnote")
+		}
+	}
 	if _, err := fmt.Fprintln(w); err != nil {
 		return false, errors.Wrap(err, "write separator")
 	}
@@ -88,6 +99,24 @@ func resultLabel(pass bool) string {
 		return "PASS"
 	}
 	return "**FAIL**"
+}
+
+// thresholdLabel renders a threshold value with a trailing "*" when an override
+// was applied, paired with a table footnote (`* = override applied`).
+func thresholdLabel(t float64, overridden bool) string {
+	if overridden {
+		return fmt.Sprintf("%.1f%%*", t)
+	}
+	return fmt.Sprintf("%.1f%%", t)
+}
+
+// boolToInt is a sort helper: false sorts before true, so passing it to
+// cmp.Compare(boolToInt(a), boolToInt(b)) puts FAIL rows ahead of PASS rows.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // writeIDList writes a "#### <label> (N)" section with a bulleted list of IDs.


### PR DESCRIPTION
## Summary

- Adds `--change-rate-threshold-override <key>=<rate>` (repeatable cobra `StringSliceVar`) to both `vuls diff db` and `vuls diff detection`. A specific ecosystem or scan-result file can now be relaxed without weakening the default threshold for the rest.
- Reports gain a per-row `Threshold` column that always shows the resolved value, so each row is self-contained. Sort order is status (FAIL first) → rate desc → name asc so a high-rate row hidden behind PASS no longer pushes legitimate FAIL rows below the fold.
- The exit error stays threshold-free ("…exceeded the applicable threshold for at least one ecosystem; see report for details") so a failure caused by an override is not misattributed to the default value.
- Override parsing happens in `RunE`; malformed entries (missing `=`, empty key, non-numeric / non-finite / negative rate) abort with an `unexpected X. expected: A, actual: B` style error.

## Why

The current single `--change-rate-threshold` (default 5% detection / 10% db in vuls-data-db's diff-guard) forces the same threshold across every ecosystem and scan-result file. Recent operational pain has been driven by individual targets tripping the guard for upstream-driven, non-regression reasons:

- `ubuntu:26.04` — 19.8% DB drift on the new distro generation (large structural churn from the initial data import).
- `debian_13` — 6.0% detection drift after 127 brand-new CVEs landed in upstream feed.

In both cases manual promote-tag overrides were required even though nothing was wrong with the build. Per-target overrides let the strict default keep guarding mature distros while letting individually-justified targets pass automatically.

## Behavior

- **Pass/fail computation is unchanged for nil/empty overrides** — same diff math, same exit code. The summary table layout did change in this PR (always-on per-row Threshold column, no single header-level default value), so the markdown report bytes are not identical to the pre-PR output even when no overrides are supplied; only the pass/fail decision is.
- Override values are exact-match keys; no glob/wildcard support (kept simple by design).
- Override value of `0` is honored literally (means "fail on any non-zero rate"), not treated as "fall back to default" — done via an explicit ok-check.
- `--change-rate-threshold-override` accepts comma-separated values too (cobra StringSlice convention), so ad-hoc CLI use can write `--change-rate-threshold-override 'a=1,b=2'`.
- NaN / +Inf / -Inf rates are rejected at parse time (would otherwise propagate as silently-broken comparisons).
- Override resolution is keyed off the canonical diffm map key (or `ecosystem` parameter for the db side), independent of any `Name`/`Ecosystem` field a caller may populate inconsistently.

## Library API

- New Option: `WithChangeRateThresholdOverrides(map[string]float64)` on both `pkg/db/diff/db` and `pkg/db/diff/detection`. Callers are expected not to mutate the map after passing it.
- New field on the diff result structs: `EcosystemDiff.Threshold` and `FileDiff.Threshold`. They carry the resolved threshold (default or override — pass/fail is decided by this single value, so downstream consumers don't need to distinguish the source).

## Test plan

- [x] `go test ./pkg/db/diff/... ./pkg/cmd/diff/...` — all green
- [x] New table-driven tests in `pkg/cmd/diff/internal/override` cover: missing `=`, empty key, non-numeric / negative / NaN / Inf rate, duplicates, whitespace tolerance, nil/empty input
- [x] `TestComputeDiffs` / `TestDiffBoltDB` extended with override hit / override-below-rate / unmatched-key cases (both db and detection sides)
- [x] `TestGenerateReport` updated to exercise the new Threshold column, and a dedicated "FAIL row sorts above higher-rate PASS row" case locks the FAIL-first sort tier so it cannot regress to pure rate-desc sorting
- [ ] Wire-up smoke test via vuls-data-db's diff-guard composite action (see companion PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)