### PR TITLE
chore(ci): scope permissions per job with empty workflow defaults

### DIFF
--- a/.github/workflows/db-nightly.yml
+++ b/.github/workflows/db-nightly.yml
@@ -7,9 +7,7 @@ on:
       - completed
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/db.yml
+++ b/.github/workflows/db.yml
@@ -5,9 +5,7 @@ on:
     - cron: "0 */6 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: read
+permissions: {}
 
 jobs:
   build:

--- a/.github/workflows/docs-nightly.yml
+++ b/.github/workflows/docs-nightly.yml
@@ -7,13 +7,14 @@ on:
     branches:
       - nightly
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   deploy:
     name: Deploy the nightly documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6

--- a/.github/workflows/push-log.yml
+++ b/.github/workflows/push-log.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   log:
     runs-on: ubuntu-slim
+    permissions: {}
     steps:
       - name: Log push event
         run: echo "Push detected."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,14 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   binary:
     name: Release Binary
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       GOEXPERIMENT: jsonv2
     steps:
@@ -51,6 +52,8 @@ jobs:
   docs:
     name: Release Docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Set Tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,14 @@ name: Test
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       GOEXPERIMENT: jsonv2
     steps:


### PR DESCRIPTION
Set workflow-level permissions to {} and grant only the minimum required permissions at each job, including contents: write for docs-nightly so mike deploy --push can update gh-pages.