### PR TITLE
fix(db/search): kb-expand renders mixed-direction chains

### DIFF
--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -960,10 +961,7 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 	// that become backward "from" keys), not against len(groups).
 	neighbors := make(map[string][]directedNeighbor, 2*len(edges))
 	for k, g := range groups {
-		ids := make([]string, 0, len(g.updateIDs))
-		for id := range g.updateIDs {
-			ids = append(ids, id)
-		}
+		ids := slices.Collect(maps.Keys(g.updateIDs))
 		slices.Sort(ids)
 		neighbors[k.From] = append(neighbors[k.From], directedNeighbor{
 			To:        k.To,

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -903,7 +903,8 @@ type directedNeighbor struct {
 	Source    sourceTypes.SourceID
 	Newer     bool
 	HasKB     bool     // true when at least one KB-level edge contributes
-	UpdateIDs []string // sorted, deduplicated Update IDs (empty when no Update-level edge)
+	HasUpdate bool     // true when at least one Update-level edge contributes (UpdateIDs may still be empty if all UpdateIDs were missing)
+	UpdateIDs []string // sorted, deduplicated Update IDs (empty when no Update-level edge or all such edges had empty UpdateID)
 }
 
 // buildKBExpandNeighbors merges exp.Edges and its reverse into one adjacency
@@ -921,21 +922,31 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 	}
 	type groupAgg struct {
 		hasKB     bool
-		updateIDs map[string]struct{}
+		hasUpdate bool
+		updateIDs map[string]struct{} // lazily allocated when a non-empty UpdateID is added
 	}
 	groups := make(map[groupKey]*groupAgg)
 	addContribution := func(from, to string, source sourceTypes.SourceID, level microsoft.ExpandEdgeLevel, updateID string, newer bool) {
 		k := groupKey{From: from, To: to, Source: source, Newer: newer}
 		g, ok := groups[k]
 		if !ok {
-			g = &groupAgg{updateIDs: make(map[string]struct{})}
+			g = &groupAgg{}
 			groups[k] = g
 		}
 		switch level {
 		case microsoft.ExpandEdgeLevelKB:
 			g.hasKB = true
 		case microsoft.ExpandEdgeLevelUpdate:
+			// Record Update-level contribution even when UpdateID is empty
+			// so the explain label still reflects "this was an Update-level
+			// attestation". In current data sources MSUC and wsusscn2 always
+			// populate UpdateID, so the placeholder branch is purely
+			// defensive.
+			g.hasUpdate = true
 			if updateID != "" {
+				if g.updateIDs == nil {
+					g.updateIDs = make(map[string]struct{})
+				}
 				g.updateIDs[updateID] = struct{}{}
 			}
 		}
@@ -959,6 +970,7 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 			Source:    k.Source,
 			Newer:     k.Newer,
 			HasKB:     g.hasKB,
+			HasUpdate: g.hasUpdate,
 			UpdateIDs: ids,
 		})
 	}
@@ -1082,9 +1094,10 @@ func formatReleases(releases []string) string {
 
 // writeKBExpandSubtree renders edges as tree branches and recursively walks
 // neighbors of each target, descending bidirectionally through the unified
-// adjacency. Each edge label includes a "newer" / "older" direction tag so
-// that mixed-direction chains (a backward step followed by a forward step,
-// or vice versa) remain self-describing in a single tree.
+// adjacency. Each edge label includes a "superseded by" / "supersedes"
+// direction tag (with the parent as implicit subject) so mixed-direction
+// chains (a backward step followed by a forward step, or vice versa) remain
+// self-describing in a single tree.
 //
 // When recursing into a child, edges back to the immediate parent are
 // skipped to suppress noisy "(→ see above)" lines for the parent at every
@@ -1113,8 +1126,15 @@ func writeKBExpandSubtree(w io.Writer, neighbors map[string][]directedNeighbor, 
 		if e.HasKB {
 			levelParts = append(levelParts, "KB-level")
 		}
-		if len(e.UpdateIDs) > 0 {
-			levelParts = append(levelParts, "Updates "+strings.Join(e.UpdateIDs, ", "))
+		if e.HasUpdate {
+			if len(e.UpdateIDs) > 0 {
+				levelParts = append(levelParts, "Updates "+strings.Join(e.UpdateIDs, ", "))
+			} else {
+				// Update-level edge contributed but no UpdateID was
+				// available (defensive: current Microsoft data sources
+				// always populate UpdateID).
+				levelParts = append(levelParts, "Update-level")
+			}
 		}
 		var srcLabel string
 		if len(levelParts) > 0 {

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -978,15 +978,13 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 	// that previous releases established for the root.
 	for _, ns := range neighbors {
 		slices.SortFunc(ns, func(a, b directedNeighbor) int {
-			var an, bn int
-			if !a.Newer {
-				an = 1
-			}
-			if !b.Newer {
-				bn = 1
+			switch {
+			case a.Newer && !b.Newer:
+				return -1
+			case !a.Newer && b.Newer:
+				return 1
 			}
 			return cmp.Or(
-				cmp.Compare(an, bn),
 				cmp.Compare(a.To, b.To),
 				cmp.Compare(string(a.Source), string(b.Source)),
 			)

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -887,45 +887,111 @@ func writeKBExpandConflicts(w io.Writer, conflicts []string) error {
 	return nil
 }
 
+// directedNeighbor is an edge in the unified bidirectional adjacency used by
+// the explain tree, consolidated by (To, Source, Direction). All KB-level
+// and Update-level attestations from the same data source pointing in the
+// same direction to the same target are merged into a single neighbor so
+// that the tree shows one line per (data source, direction) pair rather
+// than one line per Update. The original UpdateIDs are preserved in the
+// label.
+//
+// Newer=true means "To" is a KB that supersedes the source node (the source
+// is superseded by To); Newer=false means "To" is an older KB that the
+// source node supersedes.
+type directedNeighbor struct {
+	To        string
+	Source    sourceTypes.SourceID
+	Newer     bool
+	HasKB     bool     // true when at least one KB-level edge contributes
+	UpdateIDs []string // sorted, deduplicated Update IDs (empty when no Update-level edge)
+}
+
+// buildKBExpandNeighbors merges exp.Edges and its reverse into one adjacency
+// keyed by node, where every edge carries an explicit direction and all
+// attestations of the same (target, source, direction) tuple are
+// consolidated. This lets the tree printer descend through any KB the
+// bidirectional walk in microsoft.ExpandKBs discovered (including KBs
+// reached via mixed-direction chains) without exploding the output with one
+// line per MSUC Update.
+func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string][]directedNeighbor {
+	type groupKey struct {
+		From, To string
+		Source   sourceTypes.SourceID
+		Newer    bool
+	}
+	type groupAgg struct {
+		hasKB     bool
+		updateIDs map[string]struct{}
+	}
+	groups := make(map[groupKey]*groupAgg)
+	addContribution := func(from, to string, source sourceTypes.SourceID, level microsoft.ExpandEdgeLevel, updateID string, newer bool) {
+		k := groupKey{From: from, To: to, Source: source, Newer: newer}
+		g, ok := groups[k]
+		if !ok {
+			g = &groupAgg{updateIDs: make(map[string]struct{})}
+			groups[k] = g
+		}
+		switch level {
+		case microsoft.ExpandEdgeLevelKB:
+			g.hasKB = true
+		case microsoft.ExpandEdgeLevelUpdate:
+			if updateID != "" {
+				g.updateIDs[updateID] = struct{}{}
+			}
+		}
+	}
+	for from, es := range edges {
+		for _, e := range es {
+			addContribution(from, e.To, e.Source, e.Level, e.UpdateID, true)
+			addContribution(e.To, from, e.Source, e.Level, e.UpdateID, false)
+		}
+	}
+
+	neighbors := make(map[string][]directedNeighbor, len(groups))
+	for k, g := range groups {
+		ids := make([]string, 0, len(g.updateIDs))
+		for id := range g.updateIDs {
+			ids = append(ids, id)
+		}
+		slices.Sort(ids)
+		neighbors[k.From] = append(neighbors[k.From], directedNeighbor{
+			To:        k.To,
+			Source:    k.Source,
+			Newer:     k.Newer,
+			HasKB:     g.hasKB,
+			UpdateIDs: ids,
+		})
+	}
+	// Sort each adjacency list so that forward (newer) edges appear before
+	// backward (older) edges, then by (To, Source). Sorting "newer first"
+	// preserves the section ordering ("Superseded by:" before "Supersedes:")
+	// that previous releases established for the root.
+	for _, ns := range neighbors {
+		slices.SortFunc(ns, func(a, b directedNeighbor) int {
+			var an, bn int
+			if !a.Newer {
+				an = 1
+			}
+			if !b.Newer {
+				bn = 1
+			}
+			return cmp.Or(
+				cmp.Compare(an, bn),
+				cmp.Compare(a.To, b.To),
+				cmp.Compare(string(a.Source), string(b.Source)),
+			)
+		})
+	}
+	return neighbors
+}
+
 func writeKBExpandChains(w io.Writer, exp *microsoft.ExpandResult, classify func(string) string) error {
 	if _, err := fmt.Fprintln(w, "Supersession chains:"); err != nil {
 		return errors.Wrap(err, "write chains header")
 	}
 
 	roots := dedupedRoots(exp.Inputs.Applied, exp.Inputs.Unapplied)
-
-	// incoming is the reverse of exp.Edges: incoming[X] lists edges whose
-	// To is X, with To rewritten to point at the original "from" KB.
-	// Walking incoming from a root surfaces the older KBs that root
-	// supersedes (either via Supersedes on root, or via SupersededBy on
-	// those older KBs). Without this, an input KB that sits at the newer
-	// end of its chain would render with no children even though it
-	// covers older KBs.
-	incoming := make(map[string][]microsoft.ExpandEdge, len(exp.Edges))
-	for from, es := range exp.Edges {
-		for _, e := range es {
-			incoming[e.To] = append(incoming[e.To], microsoft.ExpandEdge{
-				To:       from,
-				Source:   e.Source,
-				Level:    e.Level,
-				UpdateID: e.UpdateID,
-			})
-		}
-	}
-	// The outer range over exp.Edges visits "from" keys in map-iteration
-	// order, so incoming[X] is appended in a non-deterministic order even
-	// though each exp.Edges[from] is already sorted. Sort each value slice
-	// to stabilise the "Supersedes:" section across runs.
-	for _, es := range incoming {
-		slices.SortFunc(es, func(a, b microsoft.ExpandEdge) int {
-			return cmp.Or(
-				cmp.Compare(a.To, b.To),
-				cmp.Compare(string(a.Source), string(b.Source)),
-				cmp.Compare(int(a.Level), int(b.Level)),
-				cmp.Compare(a.UpdateID, b.UpdateID),
-			)
-		})
-	}
+	neighbors := buildKBExpandNeighbors(exp.Edges)
 
 	// emittedSubtree tracks nodes whose subtrees have already been printed
 	// in this run. The first occurrence of a KB renders fully; subsequent
@@ -940,24 +1006,30 @@ func writeKBExpandChains(w io.Writer, exp *microsoft.ExpandResult, classify func
 		}
 		emittedSubtree[root] = struct{}{}
 
-		hasForward := len(exp.Edges[root]) > 0
-		hasBackward := len(incoming[root]) > 0
-		if !hasForward && !hasBackward {
+		var fwd, bwd []directedNeighbor
+		for _, n := range neighbors[root] {
+			if n.Newer {
+				fwd = append(fwd, n)
+			} else {
+				bwd = append(bwd, n)
+			}
+		}
+		if len(fwd) == 0 && len(bwd) == 0 {
 			continue
 		}
-		if hasForward {
+		if len(fwd) > 0 {
 			if _, err := fmt.Fprintln(w, "    Superseded by:"); err != nil {
 				return errors.Wrapf(err, "write Superseded by header for root %s", root)
 			}
-			if err := writeKBExpandSubtree(w, exp.Edges, classify, root, "      ", emittedSubtree); err != nil {
+			if err := writeKBExpandSubtree(w, neighbors, classify, fwd, root, "      ", emittedSubtree); err != nil {
 				return errors.Wrapf(err, "write Superseded by subtree for root %s", root)
 			}
 		}
-		if hasBackward {
+		if len(bwd) > 0 {
 			if _, err := fmt.Fprintln(w, "    Supersedes:"); err != nil {
 				return errors.Wrapf(err, "write Supersedes header for root %s", root)
 			}
-			if err := writeKBExpandSubtree(w, incoming, classify, root, "      ", emittedSubtree); err != nil {
+			if err := writeKBExpandSubtree(w, neighbors, classify, bwd, root, "      ", emittedSubtree); err != nil {
 				return errors.Wrapf(err, "write Supersedes subtree for root %s", root)
 			}
 		}
@@ -1008,39 +1080,67 @@ func formatReleases(releases []string) string {
 	return fmt.Sprintf("[%s]", strings.Join(quoted, ", "))
 }
 
-// writeKBExpandSubtree walks the adjacency map from the given node and
-// writes each reachable edge as a tree branch. The adjacency map can be
-// the forward map (exp.Edges) for the "Superseded by" view or the reverse
-// map for the "Supersedes" view; the rendering is identical because the
-// edge metadata (source, level, update id) describes the same logical
-// relationship regardless of direction.
-func writeKBExpandSubtree(w io.Writer, adj map[string][]microsoft.ExpandEdge, classify func(string) string, from string, indent string, emittedSubtree map[string]struct{}) error {
-	edges := adj[from]
+// writeKBExpandSubtree renders edges as tree branches and recursively walks
+// neighbors of each target, descending bidirectionally through the unified
+// adjacency. Each edge label includes a "newer" / "older" direction tag so
+// that mixed-direction chains (a backward step followed by a forward step,
+// or vice versa) remain self-describing in a single tree.
+//
+// When recursing into a child, edges back to the immediate parent are
+// skipped to suppress noisy "(→ see above)" lines for the parent at every
+// node. Cycles between non-parent ancestors are still surfaced through
+// emittedSubtree's "(→ see above)" marker.
+func writeKBExpandSubtree(w io.Writer, neighbors map[string][]directedNeighbor, classify func(string) string, edges []directedNeighbor, parent string, indent string, emittedSubtree map[string]struct{}) error {
 	for i, e := range edges {
 		branch, nextIndent := "├─", fmt.Sprintf("%s│   ", indent)
 		if i == len(edges)-1 {
 			branch, nextIndent = "└─", fmt.Sprintf("%s    ", indent)
 		}
+		// Direction label uses the same vocabulary as the section headers
+		// ("Superseded by:" / "Supersedes:") with the parent as the implicit
+		// subject. Newer=true means the parent is superseded by the child;
+		// Newer=false means the parent supersedes the child.
+		dirLabel := "superseded by"
+		if !e.Newer {
+			dirLabel = "supersedes"
+		}
+		// Attestations of the same (To, Source, Direction) are consolidated
+		// into one label. The form is always "Updates <id1>, <id2>, ..."
+		// (plural even for one Update) so the visual structure stays the
+		// same regardless of the attestation count, and the trailing
+		// direction word remains an unambiguous label terminator.
+		var levelParts []string
+		if e.HasKB {
+			levelParts = append(levelParts, "KB-level")
+		}
+		if len(e.UpdateIDs) > 0 {
+			levelParts = append(levelParts, "Updates "+strings.Join(e.UpdateIDs, ", "))
+		}
 		var srcLabel string
-		switch e.Level {
-		case microsoft.ExpandEdgeLevelKB:
-			srcLabel = fmt.Sprintf("%s, KB-level", e.Source)
-		case microsoft.ExpandEdgeLevelUpdate:
-			srcLabel = fmt.Sprintf("%s, Update %s", e.Source, e.UpdateID)
-		default:
-			srcLabel = string(e.Source)
+		if len(levelParts) > 0 {
+			srcLabel = fmt.Sprintf("%s, %s, %s", e.Source, strings.Join(levelParts, " + "), dirLabel)
+		} else {
+			srcLabel = fmt.Sprintf("%s, %s", e.Source, dirLabel)
 		}
 		if _, ok := emittedSubtree[e.To]; ok {
 			if _, err := fmt.Fprintf(w, "%s%s [%s] %s  (→ see above)\n", indent, branch, srcLabel, e.To); err != nil {
-				return errors.Wrapf(err, "write subtree edge %s -> %s", from, e.To)
+				return errors.Wrapf(err, "write subtree edge %s -> %s", parent, e.To)
 			}
 			continue
 		}
 		if _, err := fmt.Fprintf(w, "%s%s [%s] %s  %s\n", indent, branch, srcLabel, e.To, classify(e.To)); err != nil {
-			return errors.Wrapf(err, "write subtree edge %s -> %s", from, e.To)
+			return errors.Wrapf(err, "write subtree edge %s -> %s", parent, e.To)
 		}
 		emittedSubtree[e.To] = struct{}{}
-		if err := writeKBExpandSubtree(w, adj, classify, e.To, nextIndent, emittedSubtree); err != nil {
+
+		var childEdges []directedNeighbor
+		for _, n := range neighbors[e.To] {
+			if n.To == parent {
+				continue
+			}
+			childEdges = append(childEdges, n)
+		}
+		if err := writeKBExpandSubtree(w, neighbors, classify, childEdges, e.To, nextIndent, emittedSubtree); err != nil {
 			return errors.Wrapf(err, "walk subtree under %s", e.To)
 		}
 	}

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -1026,9 +1026,6 @@ func writeKBExpandChains(w io.Writer, exp *microsoft.ExpandResult, classify func
 				bwd = append(bwd, n)
 			}
 		}
-		if len(fwd) == 0 && len(bwd) == 0 {
-			continue
-		}
 		if len(fwd) > 0 {
 			if _, err := fmt.Fprintln(w, "    Superseded by:"); err != nil {
 				return errors.Wrapf(err, "write Superseded by header for root %s", root)

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -958,7 +958,10 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 		}
 	}
 
-	neighbors := make(map[string][]directedNeighbor, len(groups))
+	// The map is keyed by KB ID, not by edge tuple, so size it against the
+	// number of distinct nodes (forward "from" keys plus their "to" targets
+	// that become backward "from" keys), not against len(groups).
+	neighbors := make(map[string][]directedNeighbor, 2*len(edges))
 	for k, g := range groups {
 		ids := make([]string, 0, len(g.updateIDs))
 		for id := range g.updateIDs {
@@ -1153,7 +1156,7 @@ func writeKBExpandSubtree(w io.Writer, neighbors map[string][]directedNeighbor, 
 		}
 		emittedSubtree[e.To] = struct{}{}
 
-		var childEdges []directedNeighbor
+		childEdges := make([]directedNeighbor, 0, len(neighbors[e.To]))
 		for _, n := range neighbors[e.To] {
 			if n.To == parent {
 				continue

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -925,14 +925,10 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 		hasUpdate bool
 		updateIDs map[string]struct{} // lazily allocated when a non-empty UpdateID is added
 	}
-	groups := make(map[groupKey]*groupAgg)
+	groups := make(map[groupKey]groupAgg)
 	addContribution := func(from, to string, source sourceTypes.SourceID, level microsoft.ExpandEdgeLevel, updateID string, newer bool) {
 		k := groupKey{From: from, To: to, Source: source, Newer: newer}
-		g, ok := groups[k]
-		if !ok {
-			g = &groupAgg{}
-			groups[k] = g
-		}
+		g := groups[k]
 		switch level {
 		case microsoft.ExpandEdgeLevelKB:
 			g.hasKB = true
@@ -950,6 +946,7 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 				g.updateIDs[updateID] = struct{}{}
 			}
 		}
+		groups[k] = g
 	}
 	for from, es := range edges {
 		for _, e := range es {

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -1128,7 +1128,7 @@ func writeKBExpandSubtree(w io.Writer, neighbors map[string][]directedNeighbor, 
 		}
 		if e.HasUpdate {
 			if len(e.UpdateIDs) > 0 {
-				levelParts = append(levelParts, "Updates "+strings.Join(e.UpdateIDs, ", "))
+				levelParts = append(levelParts, fmt.Sprintf("Updates %s", strings.Join(e.UpdateIDs, ", ")))
 			} else {
 				// Update-level edge contributed but no UpdateID was
 				// available (defensive: current Microsoft data sources

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -985,8 +985,9 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 						return -1
 					case !a.Newer && b.Newer:
 						return 1
+					default:
+						return 0
 					}
-					return 0
 				}(),
 				cmp.Compare(a.To, b.To),
 				cmp.Compare(string(a.Source), string(b.Source)),

--- a/pkg/db/search/search.go
+++ b/pkg/db/search/search.go
@@ -978,13 +978,16 @@ func buildKBExpandNeighbors(edges map[string][]microsoft.ExpandEdge) map[string]
 	// that previous releases established for the root.
 	for _, ns := range neighbors {
 		slices.SortFunc(ns, func(a, b directedNeighbor) int {
-			switch {
-			case a.Newer && !b.Newer:
-				return -1
-			case !a.Newer && b.Newer:
-				return 1
-			}
 			return cmp.Or(
+				func() int {
+					switch {
+					case a.Newer && !b.Newer:
+						return -1
+					case !a.Newer && b.Newer:
+						return 1
+					}
+					return 0
+				}(),
 				cmp.Compare(a.To, b.To),
 				cmp.Compare(string(a.Source), string(b.Source)),
 			)

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -46,7 +46,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"Supersession chains:",
 				"5000802  [input:applied, covered]",
 				"    Superseded by:",
-				"      └─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
+				"      └─ [microsoft-cvrf, KB-level, superseded by] 5001330  [discovered, unapplied]",
 				"Result:",
 				"Covered:   5000802",
 				"Unapplied: 5001330",
@@ -86,8 +86,8 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 			wantContains: []string{
 				"    Superseded by:",
-				"[microsoft-cvrf, KB-level] 5001330",
-				"[microsoft-msuc, Update abc-123] 5001330",
+				"[microsoft-cvrf, KB-level, superseded by] 5001330",
+				"[microsoft-msuc, Updates abc-123, superseded by] 5001330",
 				"(→ see above)",
 			},
 		},
@@ -163,8 +163,8 @@ func TestPrintKBExpandTree(t *testing.T) {
 			wantContains: []string{
 				"7000004  [input:applied, covered]",
 				"    Supersedes:",
-				"      └─ [microsoft-cvrf, KB-level] 7000003  [discovered, covered]",
-				"          └─ [microsoft-cvrf, KB-level] 7000002  [discovered, covered]",
+				"      └─ [microsoft-cvrf, KB-level, supersedes] 7000003  [discovered, covered]",
+				"          └─ [microsoft-cvrf, KB-level, supersedes] 7000002  [discovered, covered]",
 			},
 			wantNotContains: []string{"    Superseded by:"},
 		},
@@ -184,9 +184,9 @@ func TestPrintKBExpandTree(t *testing.T) {
 			wantContains: []string{
 				"7000003  [input:applied, covered]",
 				"    Superseded by:",
-				"      └─ [microsoft-cvrf, KB-level] 7000004  [discovered, unapplied]",
+				"      └─ [microsoft-cvrf, KB-level, superseded by] 7000004  [discovered, unapplied]",
 				"    Supersedes:",
-				"      └─ [microsoft-cvrf, KB-level] 7000002  [discovered, covered]",
+				"      └─ [microsoft-cvrf, KB-level, supersedes] 7000002  [discovered, covered]",
 			},
 		},
 		{
@@ -221,8 +221,79 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 			wantContains: []string{
 				"A  [input:applied, covered]",
-				"      └─ [microsoft-cvrf, KB-level] B  [discovered, covered]",
-				"(→ see above)",
+				"      └─ [microsoft-cvrf, KB-level, superseded by] B  [discovered, covered]",
+				"      └─ [microsoft-cvrf, KB-level, supersedes] B  (→ see above)",
+			},
+		},
+		{
+			// Multiple Update-level attestations from the same source to
+			// the same target (e.g. several MSUC Update entries each
+			// documenting "5000802 SupersededBy 5001330") collapse into a
+			// single line that lists all UpdateIDs in deterministic order.
+			// A KB-level attestation from the same source joins via
+			// "KB-level + Updates ..." so the data sources stay grouped.
+			name: "multiple Update attestations from one source are consolidated",
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"5000802": {
+							{To: "5001330", Source: "microsoft-cvrf", Level: microsoft.ExpandEdgeLevelKB},
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelKB},
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "def-456"},
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "abc-123"},
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "abc-123"},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"[microsoft-cvrf, KB-level, superseded by] 5001330  [discovered, unapplied]",
+				"[microsoft-msuc, KB-level + Updates abc-123, def-456, superseded by] 5001330",
+			},
+			wantNotContains: []string{
+				"[microsoft-msuc, Update abc-123,",
+				"[microsoft-msuc, Update def-456,",
+				// no separate Updates-only line — KB-level merged into the
+				// same msuc label
+				"[microsoft-msuc, Updates abc-123, def-456, superseded by]",
+			},
+		},
+		{
+			// Mixed-direction discovery: an applied root (R) supersedes a
+			// shared older KB (S). S is also superseded by a parallel newer
+			// KB (P) on a different product line, which itself is superseded
+			// by P2. The bidirectional ExpandKBs walk reaches P and P2 via
+			// "backward to S, then forward to P, then forward to P2"; the
+			// explain tree must surface them so the user can trace where
+			// P/P2 in Unapplied came from. This case mirrors the production
+			// 5083769 → 5044284 → 5082063 → 5091157 chain (Win11 root and
+			// Server 24H2 parallel line sharing 5044284 as ancestor).
+			name: "mixed-direction chain surfaces parallel newer KBs",
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"R"}},
+					Covered:   []string{"R", "S"},
+					Unapplied: []string{"P", "P2"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"S": {
+							{To: "R", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "ud-r"},
+							{To: "P", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: "ud-p"},
+						},
+						"P": {
+							{To: "P2", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelKB},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"R  [input:applied, covered]",
+				"    Supersedes:",
+				"      └─ [microsoft-msuc, Updates ud-r, supersedes] S  [discovered, covered]",
+				"          └─ [microsoft-msuc, Updates ud-p, superseded by] P  [discovered, unapplied]",
+				"              └─ [microsoft-msuc, KB-level, superseded by] P2  [discovered, unapplied]",
 			},
 		},
 		{
@@ -245,7 +316,7 @@ func TestPrintKBExpandTree(t *testing.T) {
 				"Applied:   5000802",
 				"Unapplied: (none)",
 				"5000802  [input:applied, covered]",
-				"      └─ [microsoft-cvrf, KB-level] 5001330  [discovered, unapplied]",
+				"      └─ [microsoft-cvrf, KB-level, superseded by] 5001330  [discovered, unapplied]",
 			},
 			wantNotContains: []string{
 				"Applied:   \n",      // no stray leading/trailing space from "" entry

--- a/pkg/db/search/search_test.go
+++ b/pkg/db/search/search_test.go
@@ -262,6 +262,34 @@ func TestPrintKBExpandTree(t *testing.T) {
 			},
 		},
 		{
+			// Defensive: if microsoft.ExpandKBs ever emits an Update-level
+			// edge whose UpdateID is empty (current MSUC/wsusscn2 data
+			// always populate it, but vuls-data-update could in principle
+			// produce malformed records), the explain label must still
+			// reflect that the attestation came from Update-level data
+			// rather than silently dropping the level info.
+			name: "Update-level edge with empty UpdateID renders Update-level placeholder",
+			args: args{
+				exp: &microsoft.ExpandResult{
+					Inputs:    microsoft.ExpandInputs{Applied: []string{"5000802"}},
+					Covered:   []string{"5000802"},
+					Unapplied: []string{"5001330"},
+					Edges: map[string][]microsoft.ExpandEdge{
+						"5000802": {
+							{To: "5001330", Source: "microsoft-msuc", Level: microsoft.ExpandEdgeLevelUpdate, UpdateID: ""},
+						},
+					},
+				},
+			},
+			wantContains: []string{
+				"[microsoft-msuc, Update-level, superseded by] 5001330  [discovered, unapplied]",
+			},
+			wantNotContains: []string{
+				"[microsoft-msuc, superseded by] 5001330",
+				"[microsoft-msuc, Updates ",
+			},
+		},
+		{
 			// Mixed-direction discovery: an applied root (R) supersedes a
 			// shared older KB (S). S is also superseded by a parallel newer
 			// KB (P) on a different product line, which itself is superseded


### PR DESCRIPTION
## Summary

Two correctness/readability fixes for ``vuls db search kb-expand --explain``:

- **Mixed-direction discoverability**. ``ExpandKBs`` walks supersession edges in both directions (so a missing old→new ``SupersededBy`` can be bridged by a new→old ``Supersedes`` from any data source). The explain printer was strictly directional from each root, so KBs reached only via a backward-then-forward chain landed in ``Unapplied`` with no chain shown. For example, ``--applied 5083769`` produced ``Unapplied: 5082063 5091157`` with neither KB appearing anywhere in the tree (they reach the visited set via ``5083769 → supersedes 5044284 → superseded by 5082063 → superseded by 5091157``, where 5082063/5091157 belong to the Server 2025 product line that shares ancestor 5044284 with the Win11 23H2 input).
- **Per-Update redundancy**. MSUC publishes one entry per Update artifact, so a single logical supersession (e.g. ``5083769 SupersededBy 5083631``) is attested by ~8 distinct ``UpdateID``s. The old printer emitted one tree line per attestation, blowing up the output and obscuring the structure.

Rewrites ``writeKBExpandChains`` / ``writeKBExpandSubtree`` around a unified ``directedNeighbor`` adjacency:

- Forward (``exp.Edges``) and backward (reverse) are merged into one map, with each entry carrying a ``Newer`` flag.
- Recursion descends through ``neighbors[child]`` regardless of which direction got us there, so any KB the bidirectional walk found is reachable in the tree.
- Edges back to the immediate parent are dropped at recursion; cycles between non-parent ancestors still surface via ``(→ see above)``.
- ``(To, Source, Direction)`` tuples are consolidated: one line per ``(target, data source, direction)`` with all ``UpdateID``s listed.
- Label vocabulary matches the section headers — ``superseded by`` / ``supersedes``, with the parent as implicit subject — and the level portion is always ``KB-level`` or ``Updates <id1>, <id2>, ...`` (plural even for a single Update, so the visual shape doesn't change with count).

Real-DB measurements for ``--applied 5083769 --explain`` against today's nightly DB:

| state | line count |
|---|---|
| before | 14,513 |
| after | 3,176 |

with ``5082063`` / ``5091157`` now visible in the tree as ``[discovered, unapplied]`` along a traceable chain.

Depth (deep ``│ │ │ ...`` nesting through the 30-hop forward chain) is unchanged here — that is the DFS-descent shape and is better addressed by a separate BFS-spanning-tree pass.

## Test plan

- [x] ``go test ./...``
- [x] ``vuls db search kb-expand --dbpath vuls.db --applied 5083769 --explain`` against the real nightly DB — ``5082063`` and ``5091157`` appear with attribution; output shrinks to ~3.2k lines.
- [x] Existing ``TestPrintKBExpandTree`` cases (single chain, cycle, intermediate input, multi-source, datasource filter, release filter, empty/conflict inputs) updated to the new label form and pass.
- [x] New tests:
  - ``mixed-direction chain surfaces parallel newer KBs`` — applied root supersedes a shared old KB which is also superseded by a parallel newer KB; the parallel chain must appear in the tree.
  - ``multiple Update attestations from one source are consolidated`` — several MSUC Updates plus a KB-level edge for the same ``(target, source, direction)`` collapse into one ``KB-level + Updates <id1>, <id2>, ...`` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)