### PR TITLE
feat!(detect): move per-condition Affected gate to top-level

### DIFF
--- a/pkg/detect/detect.go
+++ b/pkg/detect/detect.go
@@ -326,7 +326,7 @@ func filterAffected(detected map[dataTypes.RootID]detectTypes.VulnerabilityData)
 	for rootID, data := range detected {
 		keptDetections := make([]detectTypes.VulnerabilityDataDetection, 0, len(data.Detections))
 		for _, d := range data.Detections {
-			keptContents := make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition)
+			keptContents := make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition, len(d.Contents))
 			for sid, conds := range d.Contents {
 				kept := make([]conditionTypes.FilteredCondition, 0, len(conds))
 				for _, cond := range conds {

--- a/pkg/detect/detect.go
+++ b/pkg/detect/detect.go
@@ -14,6 +14,7 @@ import (
 	bolt "go.etcd.io/bbolt"
 
 	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
 	datasourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/datasource"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
@@ -242,6 +243,15 @@ func detect(s *session.Session, sr scanTypes.ScanResult, concurrency int) (detec
 		detected[rootID] = base
 	}
 
+	// util.Detect now passes every condition through unconditionally, so
+	// apply the per-condition Affected gate here for the default consumer
+	// path. Conditions whose FilteredCriteria evaluates as not-affected are
+	// dropped; Detections / VulnerabilityData that end up empty are pruned.
+	detected, err = filterAffected(detected)
+	if err != nil {
+		return detectTypes.DetectResult{}, errors.Wrap(err, "filter affected")
+	}
+
 	for rootID, base := range detected {
 		d, err := s.GetVulnerabilityData(rootID, dbTypes.Filter{
 			Contents: []dbTypes.FilterContentType{
@@ -302,4 +312,47 @@ func detect(s *session.Session, sr scanTypes.ScanResult, concurrency int) (detec
 		DetectedAt: time.Now(),
 		DetectedBy: version.String(),
 	}, nil
+}
+
+// filterAffected drops conditions whose FilteredCriteria evaluates as
+// not-affected, restoring the per-condition gate that util.Detect no longer
+// applies. Detections with no remaining conditions and VulnerabilityData
+// with no remaining detections are pruned. Callers of the lower-level
+// ospkg.Detect / cpe.Detect / util.Detect that want to apply different
+// filtering rules (e.g. ecosystem-specific relaxation) can do so without
+// being short-circuited upstream.
+func filterAffected(detected map[dataTypes.RootID]detectTypes.VulnerabilityData) (map[dataTypes.RootID]detectTypes.VulnerabilityData, error) {
+	out := make(map[dataTypes.RootID]detectTypes.VulnerabilityData, len(detected))
+	for rootID, data := range detected {
+		keptDetections := make([]detectTypes.VulnerabilityDataDetection, 0, len(data.Detections))
+		for _, d := range data.Detections {
+			keptContents := make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition)
+			for sid, conds := range d.Contents {
+				kept := make([]conditionTypes.FilteredCondition, 0, len(conds))
+				for _, cond := range conds {
+					ok, err := cond.Criteria.Affected()
+					if err != nil {
+						return nil, errors.Wrapf(err, "criteria affected (rootID: %s)", rootID)
+					}
+					if ok {
+						kept = append(kept, cond)
+					}
+				}
+				if len(kept) > 0 {
+					keptContents[sid] = kept
+				}
+			}
+			if len(keptContents) == 0 {
+				continue
+			}
+			d.Contents = keptContents
+			keptDetections = append(keptDetections, d)
+		}
+		if len(keptDetections) == 0 {
+			continue
+		}
+		data.Detections = keptDetections
+		out[rootID] = data
+	}
+	return out, nil
 }

--- a/pkg/detect/detect.go
+++ b/pkg/detect/detect.go
@@ -330,11 +330,14 @@ func filterAffected(detected map[dataTypes.RootID]detectTypes.VulnerabilityData)
 			for sid, conds := range d.Contents {
 				kept := make([]conditionTypes.FilteredCondition, 0, len(conds))
 				for _, cond := range conds {
-					ok, err := cond.Criteria.Affected()
+					// Route through FilteredCondition.Affected() (rather than
+					// Criteria.Affected() directly) so any future per-condition
+					// logic added to the upstream type is picked up here.
+					isAffected, err := cond.Affected()
 					if err != nil {
-						return nil, errors.Wrapf(err, "criteria affected (rootID: %s)", rootID)
+						return nil, errors.Wrapf(err, "condition affected (rootID: %s, sourceID: %s)", rootID, sid)
 					}
-					if ok {
+					if isAffected {
 						kept = append(kept, cond)
 					}
 				}

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -35,8 +35,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "affected condition is kept",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-A": {
-					ID: "CVE-A",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -72,8 +72,8 @@ func TestFilterAffected(t *testing.T) {
 				},
 			},
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-A": {
-					ID: "CVE-A",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -112,8 +112,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "unaffected-only VulnerabilityData is pruned entirely",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-B": {
-					ID: "CVE-B",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -153,8 +153,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "within a source slot, only affected conditions are kept",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-C": {
-					ID: "CVE-C",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -219,8 +219,8 @@ func TestFilterAffected(t *testing.T) {
 				},
 			},
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-C": {
-					ID: "CVE-C",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -259,8 +259,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "source with no surviving conditions is dropped, sibling source is kept",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-D": {
-					ID: "CVE-D",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -323,8 +323,8 @@ func TestFilterAffected(t *testing.T) {
 				},
 			},
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-D": {
-					ID: "CVE-D",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -363,8 +363,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "detection with no surviving sources is dropped, sibling detection is kept",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-E": {
-					ID: "CVE-E",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{
 						{
 							Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
@@ -434,8 +434,8 @@ func TestFilterAffected(t *testing.T) {
 				},
 			},
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-E": {
-					ID: "CVE-E",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -474,8 +474,8 @@ func TestFilterAffected(t *testing.T) {
 		{
 			name: "Criteria.Affected() error is surfaced",
 			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
-				"CVE-F": {
-					ID: "CVE-F",
+				"ROOT-ID": {
+					ID: "ROOT-ID",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
 						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -1,0 +1,203 @@
+package detect
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	kbcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
+)
+
+// kbCondition returns a single-KB FilteredCondition. When unapplied is true,
+// the inner criterion's Accepts.KB.Unapplied is set so Criteria.Affected()
+// returns true; otherwise Accepts is zero and Affected() returns false.
+func kbCondition(product, kbid string, unapplied bool) conditionTypes.FilteredCondition {
+	c := criterionTypes.FilteredCriterion{
+		Criterion: criterionTypes.Criterion{
+			Type: criterionTypes.CriterionTypeKB,
+			KB:   &kbcTypes.Criterion{Product: product, KBID: kbid},
+		},
+	}
+	if unapplied {
+		c.Accepts = criterionTypes.AcceptQueries{KB: criterionTypes.KB{Unapplied: true}}
+	}
+	return conditionTypes.FilteredCondition{
+		Criteria: criteriaTypes.FilteredCriteria{
+			Operator: criteriaTypes.CriteriaOperatorTypeOR,
+			Criterias: []criteriaTypes.FilteredCriteria{
+				{
+					Operator:   criteriaTypes.CriteriaOperatorTypeAND,
+					Criterions: []criterionTypes.FilteredCriterion{c},
+				},
+			},
+		},
+	}
+}
+
+func TestFilterAffected(t *testing.T) {
+	const ms = ecosystemTypes.EcosystemTypeMicrosoft
+	const src = sourceTypes.SourceID("microsoft-cvrf")
+
+	affectedCond := kbCondition("Win10", "5000802", true)
+	unaffectedCond := kbCondition("Win10", "5001330", false)
+
+	tests := []struct {
+		name    string
+		in      map[dataTypes.RootID]detectTypes.VulnerabilityData
+		want    map[dataTypes.RootID]detectTypes.VulnerabilityData
+		wantErr bool
+	}{
+		{
+			name: "empty input yields empty output",
+			in:   map[dataTypes.RootID]detectTypes.VulnerabilityData{},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{},
+		},
+		{
+			name: "affected condition is kept",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-A": {
+					ID: "CVE-A",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+					}},
+				},
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-A": {
+					ID: "CVE-A",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+					}},
+				},
+			},
+		},
+		{
+			name: "unaffected-only VulnerabilityData is pruned entirely",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-B": {
+					ID: "CVE-B",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
+					}},
+				},
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{},
+		},
+		{
+			name: "within a source slot, only affected conditions are kept",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-C": {
+					ID: "CVE-C",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond, unaffectedCond}},
+					}},
+				},
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-C": {
+					ID: "CVE-C",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+					}},
+				},
+			},
+		},
+		{
+			name: "source with no surviving conditions is dropped, sibling source is kept",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-D": {
+					ID: "CVE-D",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							src: {affectedCond},
+							sourceTypes.SourceID("other-src"): {unaffectedCond},
+						},
+					}},
+				},
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-D": {
+					ID: "CVE-D",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+					}},
+				},
+			},
+		},
+		{
+			name: "detection with no surviving sources is dropped, sibling detection is kept",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-E": {
+					ID: "CVE-E",
+					Detections: []detectTypes.VulnerabilityDataDetection{
+						{
+							Ecosystem: ms,
+							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
+						},
+						{
+							Ecosystem: ms,
+							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						},
+					},
+				},
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-E": {
+					ID: "CVE-E",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+					}},
+				},
+			},
+		},
+		{
+			name: "Criteria.Affected() error is surfaced",
+			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+				"CVE-F": {
+					ID: "CVE-F",
+					Detections: []detectTypes.VulnerabilityDataDetection{{
+						Ecosystem: ms,
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {{
+							// Out-of-range operator triggers the default branch
+							// of FilteredCriteria.Affected() and returns an
+							// error. The valid values are the AND/OR iota
+							// constants, so any other int falls through.
+							Criteria: criteriaTypes.FilteredCriteria{Operator: criteriaTypes.CriteriaOperatorType(-1)},
+						}}},
+					}},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := filterAffected(tt.in)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("filterAffected() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("filterAffected() (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -9,24 +9,44 @@ import (
 	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
 	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
 	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
-	kbcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/kbcriterion"
+	vcTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion"
+	vcAffectedTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected"
+	vcAffectedRangeTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/affected/range"
+	vcFixStatusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/fixstatus"
+	vcPackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package"
+	vcBinaryPackageTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/package/binary"
 	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
 	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 )
 
-// kbCondition returns a single-KB FilteredCondition. When unapplied is true,
-// the inner criterion's Accepts.KB.Unapplied is set so Criteria.Affected()
-// returns true; otherwise Accepts is zero and Affected() returns false.
-func kbCondition(product, kbid string, unapplied bool) conditionTypes.FilteredCondition {
+// versionCondition returns a single-package FilteredCondition for a binary
+// rpm with a fixed-version range. When matched is true the inner criterion's
+// Accepts.Version is populated with a query index so Criteria.Affected()
+// returns true; otherwise Accepts.Version is empty and Affected() returns
+// false.
+func versionCondition(pkgName, fixed string, isAffected bool) conditionTypes.FilteredCondition {
 	c := criterionTypes.FilteredCriterion{
 		Criterion: criterionTypes.Criterion{
-			Type: criterionTypes.CriterionTypeKB,
-			KB:   &kbcTypes.Criterion{Product: product, KBID: kbid},
+			Type: criterionTypes.CriterionTypeVersion,
+			Version: &vcTypes.Criterion{
+				Vulnerable: true,
+				FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+				Package: vcPackageTypes.Package{
+					Type:   vcPackageTypes.PackageTypeBinary,
+					Binary: &vcBinaryPackageTypes.Package{Name: pkgName},
+				},
+				Affected: &vcAffectedTypes.Affected{
+					Type:  vcAffectedRangeTypes.RangeTypeRPM,
+					Range: []vcAffectedRangeTypes.Range{{LessThan: fixed}},
+					Fixed: []string{fixed},
+				},
+			},
 		},
+		Accepts: criterionTypes.AcceptQueries{Version: []int{}},
 	}
-	if unapplied {
-		c.Accepts = criterionTypes.AcceptQueries{KB: criterionTypes.KB{Unapplied: true}}
+	if isAffected {
+		c.Accepts.Version = []int{0}
 	}
 	return conditionTypes.FilteredCondition{
 		Criteria: criteriaTypes.FilteredCriteria{
@@ -42,11 +62,11 @@ func kbCondition(product, kbid string, unapplied bool) conditionTypes.FilteredCo
 }
 
 func TestFilterAffected(t *testing.T) {
-	const ms = ecosystemTypes.EcosystemTypeMicrosoft
-	const src = sourceTypes.SourceID("microsoft-cvrf")
+	const eco = ecosystemTypes.Ecosystem("redhat:9")
+	const src = sourceTypes.SourceID("redhat-ovalv2")
 
-	affectedCond := kbCondition("Win10", "5000802", true)
-	unaffectedCond := kbCondition("Win10", "5001330", false)
+	affectedCond := versionCondition("kernel", "0:5.14.0-70.13.1.el9_0", true)
+	unaffectedCond := versionCondition("openssl", "1:3.0.7-16.el9_2", false)
 
 	tests := []struct {
 		name    string
@@ -65,7 +85,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-A": {
 					ID: "CVE-A",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 					}},
 				},
@@ -74,7 +94,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-A": {
 					ID: "CVE-A",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 					}},
 				},
@@ -86,7 +106,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-B": {
 					ID: "CVE-B",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
 					}},
 				},
@@ -99,7 +119,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-C": {
 					ID: "CVE-C",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond, unaffectedCond}},
 					}},
 				},
@@ -108,7 +128,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-C": {
 					ID: "CVE-C",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 					}},
 				},
@@ -120,9 +140,9 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-D": {
 					ID: "CVE-D",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							src: {affectedCond},
+							src:                               {affectedCond},
 							sourceTypes.SourceID("other-src"): {unaffectedCond},
 						},
 					}},
@@ -132,7 +152,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-D": {
 					ID: "CVE-D",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 					}},
 				},
@@ -145,11 +165,11 @@ func TestFilterAffected(t *testing.T) {
 					ID: "CVE-E",
 					Detections: []detectTypes.VulnerabilityDataDetection{
 						{
-							Ecosystem: ms,
+							Ecosystem: eco,
 							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
 						},
 						{
-							Ecosystem: ms,
+							Ecosystem: eco,
 							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 						},
 					},
@@ -159,7 +179,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-E": {
 					ID: "CVE-E",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
 					}},
 				},
@@ -171,7 +191,7 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-F": {
 					ID: "CVE-F",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: ms,
+						Ecosystem: eco,
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {{
 							// Out-of-range operator triggers the default branch
 							// of FilteredCriteria.Affected() and returns an

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -70,18 +70,18 @@ func TestFilterAffected(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		in      map[dataTypes.RootID]detectTypes.VulnerabilityData
+		arg     map[dataTypes.RootID]detectTypes.VulnerabilityData
 		want    map[dataTypes.RootID]detectTypes.VulnerabilityData
 		wantErr bool
 	}{
 		{
 			name: "empty input yields empty output",
-			in:   map[dataTypes.RootID]detectTypes.VulnerabilityData{},
+			arg:  map[dataTypes.RootID]detectTypes.VulnerabilityData{},
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityData{},
 		},
 		{
 			name: "affected condition is kept",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-A": {
 					ID: "CVE-A",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
@@ -102,7 +102,7 @@ func TestFilterAffected(t *testing.T) {
 		},
 		{
 			name: "unaffected-only VulnerabilityData is pruned entirely",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-B": {
 					ID: "CVE-B",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
@@ -115,7 +115,7 @@ func TestFilterAffected(t *testing.T) {
 		},
 		{
 			name: "within a source slot, only affected conditions are kept",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-C": {
 					ID: "CVE-C",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
@@ -136,7 +136,7 @@ func TestFilterAffected(t *testing.T) {
 		},
 		{
 			name: "source with no surviving conditions is dropped, sibling source is kept",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-D": {
 					ID: "CVE-D",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
@@ -160,7 +160,7 @@ func TestFilterAffected(t *testing.T) {
 		},
 		{
 			name: "detection with no surviving sources is dropped, sibling detection is kept",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-E": {
 					ID: "CVE-E",
 					Detections: []detectTypes.VulnerabilityDataDetection{
@@ -187,7 +187,7 @@ func TestFilterAffected(t *testing.T) {
 		},
 		{
 			name: "Criteria.Affected() error is surfaced",
-			in: map[dataTypes.RootID]detectTypes.VulnerabilityData{
+			arg: map[dataTypes.RootID]detectTypes.VulnerabilityData{
 				"CVE-F": {
 					ID: "CVE-F",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
@@ -208,7 +208,7 @@ func TestFilterAffected(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := filterAffected(tt.in)
+			got, err := filterAffected(tt.arg)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("filterAffected() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -20,54 +20,7 @@ import (
 	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 )
 
-// versionCondition returns a single-package FilteredCondition for a binary
-// rpm with a fixed-version range. When isAffected is true the inner
-// criterion's Accepts.Version is populated with a query index so
-// Criteria.Affected() returns true; otherwise Accepts.Version is empty
-// and Affected() returns false.
-func versionCondition(pkgName, fixed string, isAffected bool) conditionTypes.FilteredCondition {
-	c := criterionTypes.FilteredCriterion{
-		Criterion: criterionTypes.Criterion{
-			Type: criterionTypes.CriterionTypeVersion,
-			Version: &vcTypes.Criterion{
-				Vulnerable: true,
-				FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
-				Package: vcPackageTypes.Package{
-					Type:   vcPackageTypes.PackageTypeBinary,
-					Binary: &vcBinaryPackageTypes.Package{Name: pkgName},
-				},
-				Affected: &vcAffectedTypes.Affected{
-					Type:  vcAffectedRangeTypes.RangeTypeRPM,
-					Range: []vcAffectedRangeTypes.Range{{LessThan: fixed}},
-					Fixed: []string{fixed},
-				},
-			},
-		},
-		Accepts: criterionTypes.AcceptQueries{Version: []int{}},
-	}
-	if isAffected {
-		c.Accepts.Version = []int{0}
-	}
-	return conditionTypes.FilteredCondition{
-		Criteria: criteriaTypes.FilteredCriteria{
-			Operator: criteriaTypes.CriteriaOperatorTypeOR,
-			Criterias: []criteriaTypes.FilteredCriteria{
-				{
-					Operator:   criteriaTypes.CriteriaOperatorTypeAND,
-					Criterions: []criterionTypes.FilteredCriterion{c},
-				},
-			},
-		},
-	}
-}
-
 func TestFilterAffected(t *testing.T) {
-	const eco = ecosystemTypes.Ecosystem("redhat:9")
-	const src = sourceTypes.RedHatOVALv2
-
-	affectedCond := versionCondition("kernel", "0:5.14.0-70.13.1.el9_0", true)
-	unaffectedCond := versionCondition("openssl", "1:3.0.7-16.el9_2", false)
-
 	tests := []struct {
 		name    string
 		arg     map[dataTypes.RootID]detectTypes.VulnerabilityData
@@ -85,8 +38,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-A": {
 					ID: "CVE-A",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -94,8 +75,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-A": {
 					ID: "CVE-A",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -106,8 +115,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-B": {
 					ID: "CVE-B",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "openssl"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "1:3.0.7-16.el9_2"}},
+														Fixed: []string{"1:3.0.7-16.el9_2"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -119,8 +156,65 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-C": {
 					ID: "CVE-C",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond, unaffectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {
+								{
+									Criteria: criteriaTypes.FilteredCriteria{
+										Operator: criteriaTypes.CriteriaOperatorTypeOR,
+										Criterias: []criteriaTypes.FilteredCriteria{{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{{
+												Criterion: criterionTypes.Criterion{
+													Type: criterionTypes.CriterionTypeVersion,
+													Version: &vcTypes.Criterion{
+														Vulnerable: true,
+														FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+														Package: vcPackageTypes.Package{
+															Type:   vcPackageTypes.PackageTypeBinary,
+															Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+														},
+														Affected: &vcAffectedTypes.Affected{
+															Type:  vcAffectedRangeTypes.RangeTypeRPM,
+															Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+															Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+														},
+													},
+												},
+												Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+											}},
+										}},
+									},
+								},
+								{
+									Criteria: criteriaTypes.FilteredCriteria{
+										Operator: criteriaTypes.CriteriaOperatorTypeOR,
+										Criterias: []criteriaTypes.FilteredCriteria{{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{{
+												Criterion: criterionTypes.Criterion{
+													Type: criterionTypes.CriterionTypeVersion,
+													Version: &vcTypes.Criterion{
+														Vulnerable: true,
+														FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+														Package: vcPackageTypes.Package{
+															Type:   vcPackageTypes.PackageTypeBinary,
+															Binary: &vcBinaryPackageTypes.Package{Name: "openssl"},
+														},
+														Affected: &vcAffectedTypes.Affected{
+															Type:  vcAffectedRangeTypes.RangeTypeRPM,
+															Range: []vcAffectedRangeTypes.Range{{LessThan: "1:3.0.7-16.el9_2"}},
+															Fixed: []string{"1:3.0.7-16.el9_2"},
+														},
+													},
+												},
+												Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+											}},
+										}},
+									},
+								},
+							},
+						},
 					}},
 				},
 			},
@@ -128,8 +222,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-C": {
 					ID: "CVE-C",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -140,10 +262,62 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-D": {
 					ID: "CVE-D",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
 						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
-							src:                               {affectedCond},
-							sourceTypes.SourceID("other-src"): {unaffectedCond},
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+							sourceTypes.SourceID("other-src"): {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "openssl"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "1:3.0.7-16.el9_2"}},
+														Fixed: []string{"1:3.0.7-16.el9_2"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+										}},
+									}},
+								},
+							}},
 						},
 					}},
 				},
@@ -152,8 +326,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-D": {
 					ID: "CVE-D",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -165,12 +367,68 @@ func TestFilterAffected(t *testing.T) {
 					ID: "CVE-E",
 					Detections: []detectTypes.VulnerabilityDataDetection{
 						{
-							Ecosystem: eco,
-							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {unaffectedCond}},
+							Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+							Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.RedHatOVALv2: {{
+									Criteria: criteriaTypes.FilteredCriteria{
+										Operator: criteriaTypes.CriteriaOperatorTypeOR,
+										Criterias: []criteriaTypes.FilteredCriteria{{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{{
+												Criterion: criterionTypes.Criterion{
+													Type: criterionTypes.CriterionTypeVersion,
+													Version: &vcTypes.Criterion{
+														Vulnerable: true,
+														FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+														Package: vcPackageTypes.Package{
+															Type:   vcPackageTypes.PackageTypeBinary,
+															Binary: &vcBinaryPackageTypes.Package{Name: "openssl"},
+														},
+														Affected: &vcAffectedTypes.Affected{
+															Type:  vcAffectedRangeTypes.RangeTypeRPM,
+															Range: []vcAffectedRangeTypes.Range{{LessThan: "1:3.0.7-16.el9_2"}},
+															Fixed: []string{"1:3.0.7-16.el9_2"},
+														},
+													},
+												},
+												Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+											}},
+										}},
+									},
+								}},
+							},
 						},
 						{
-							Ecosystem: eco,
-							Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+							Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+							Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+								sourceTypes.RedHatOVALv2: {{
+									Criteria: criteriaTypes.FilteredCriteria{
+										Operator: criteriaTypes.CriteriaOperatorTypeOR,
+										Criterias: []criteriaTypes.FilteredCriteria{{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{{
+												Criterion: criterionTypes.Criterion{
+													Type: criterionTypes.CriterionTypeVersion,
+													Version: &vcTypes.Criterion{
+														Vulnerable: true,
+														FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+														Package: vcPackageTypes.Package{
+															Type:   vcPackageTypes.PackageTypeBinary,
+															Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+														},
+														Affected: &vcAffectedTypes.Affected{
+															Type:  vcAffectedRangeTypes.RangeTypeRPM,
+															Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+															Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+														},
+													},
+												},
+												Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+											}},
+										}},
+									},
+								}},
+							},
 						},
 					},
 				},
@@ -179,8 +437,36 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-E": {
 					ID: "CVE-E",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents:  map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {affectedCond}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{{
+										Operator: criteriaTypes.CriteriaOperatorTypeAND,
+										Criterions: []criterionTypes.FilteredCriterion{{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type:   vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{Name: "kernel"},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "0:5.14.0-70.13.1.el9_0"}},
+														Fixed: []string{"0:5.14.0-70.13.1.el9_0"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{0}},
+										}},
+									}},
+								},
+							}},
+						},
 					}},
 				},
 			},
@@ -191,14 +477,16 @@ func TestFilterAffected(t *testing.T) {
 				"CVE-F": {
 					ID: "CVE-F",
 					Detections: []detectTypes.VulnerabilityDataDetection{{
-						Ecosystem: eco,
-						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{src: {{
-							// Out-of-range operator triggers the default branch
-							// of FilteredCriteria.Affected() and returns an
-							// error. The valid values are the AND/OR iota
-							// constants, so any other int falls through.
-							Criteria: criteriaTypes.FilteredCriteria{Operator: criteriaTypes.CriteriaOperatorType(-1)},
-						}}},
+						Ecosystem: ecosystemTypes.Ecosystem("redhat:9"),
+						Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+							sourceTypes.RedHatOVALv2: {{
+								// Out-of-range operator triggers the default branch
+								// of FilteredCriteria.Affected() and returns an
+								// error. The valid values are the AND/OR iota
+								// constants, so any other int falls through.
+								Criteria: criteriaTypes.FilteredCriteria{Operator: criteriaTypes.CriteriaOperatorType(-1)},
+							}},
+						},
 					}},
 				},
 			},

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 // versionCondition returns a single-package FilteredCondition for a binary
-// rpm with a fixed-version range. When matched is true the inner criterion's
-// Accepts.Version is populated with a query index so Criteria.Affected()
-// returns true; otherwise Accepts.Version is empty and Affected() returns
-// false.
+// rpm with a fixed-version range. When isAffected is true the inner
+// criterion's Accepts.Version is populated with a query index so
+// Criteria.Affected() returns true; otherwise Accepts.Version is empty
+// and Affected() returns false.
 func versionCondition(pkgName, fixed string, isAffected bool) conditionTypes.FilteredCondition {
 	c := criterionTypes.FilteredCriterion{
 		Criterion: criterionTypes.Criterion{

--- a/pkg/detect/detect_test.go
+++ b/pkg/detect/detect_test.go
@@ -63,7 +63,7 @@ func versionCondition(pkgName, fixed string, isAffected bool) conditionTypes.Fil
 
 func TestFilterAffected(t *testing.T) {
 	const eco = ecosystemTypes.Ecosystem("redhat:9")
-	const src = sourceTypes.SourceID("redhat-ovalv2")
+	const src = sourceTypes.RedHatOVALv2
 
 	affectedCond := versionCondition("kernel", "0:5.14.0-70.13.1.el9_0", true)
 	unaffectedCond := versionCondition("openssl", "1:3.0.7-16.el9_2", false)

--- a/pkg/detect/internal/test/test.go
+++ b/pkg/detect/internal/test/test.go
@@ -6,11 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
-	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
-	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
-	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 )
 
 // PopulateDB populates the database specified by c with test data from fixtureDir.
@@ -50,46 +46,4 @@ func PopulateDB(c session.Config, fixtureDir string) error {
 	}
 
 	return nil
-}
-
-// FilterAffected mirrors the top-level per-condition Affected gate applied
-// in pkg/detect.Detect. Lower-level Detect functions (ospkg, cpe, util) now
-// pass every condition through unconditionally, so tests that previously
-// asserted only the affected subset use this helper to reproduce the
-// filtered view.
-func FilterAffected(t require, in map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection) map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection {
-	if in == nil {
-		return nil
-	}
-	out := make(map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, len(in))
-	for rootID, d := range in {
-		keptContents := make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition)
-		for sid, conds := range d.Contents {
-			kept := make([]conditionTypes.FilteredCondition, 0, len(conds))
-			for _, cond := range conds {
-				ok, err := cond.Criteria.Affected()
-				if err != nil {
-					t.Fatalf("criteria affected (rootID: %s): %v", rootID, err)
-				}
-				if ok {
-					kept = append(kept, cond)
-				}
-			}
-			if len(kept) > 0 {
-				keptContents[sid] = kept
-			}
-		}
-		if len(keptContents) == 0 {
-			continue
-		}
-		d.Contents = keptContents
-		out[rootID] = d
-	}
-	return out
-}
-
-// require is a tiny subset of testing.TB so this helper can stay decoupled
-// from the testing package while still surfacing fatal errors to the caller.
-type require interface {
-	Fatalf(format string, args ...any)
 }

--- a/pkg/detect/internal/test/test.go
+++ b/pkg/detect/internal/test/test.go
@@ -6,7 +6,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
 	"github.com/MaineK00n/vuls2/pkg/db/session"
+	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
 )
 
 // PopulateDB populates the database specified by c with test data from fixtureDir.
@@ -46,4 +50,46 @@ func PopulateDB(c session.Config, fixtureDir string) error {
 	}
 
 	return nil
+}
+
+// FilterAffected mirrors the top-level per-condition Affected gate applied
+// in pkg/detect.Detect. Lower-level Detect functions (ospkg, cpe, util) now
+// pass every condition through unconditionally, so tests that previously
+// asserted only the affected subset use this helper to reproduce the
+// filtered view.
+func FilterAffected(t require, in map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection) map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection {
+	if in == nil {
+		return nil
+	}
+	out := make(map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection, len(in))
+	for rootID, d := range in {
+		keptContents := make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition)
+		for sid, conds := range d.Contents {
+			kept := make([]conditionTypes.FilteredCondition, 0, len(conds))
+			for _, cond := range conds {
+				ok, err := cond.Criteria.Affected()
+				if err != nil {
+					t.Fatalf("criteria affected (rootID: %s): %v", rootID, err)
+				}
+				if ok {
+					kept = append(kept, cond)
+				}
+			}
+			if len(kept) > 0 {
+				keptContents[sid] = kept
+			}
+		}
+		if len(keptContents) == 0 {
+			continue
+		}
+		d.Contents = keptContents
+		out[rootID] = d
+	}
+	return out
+}
+
+// require is a tiny subset of testing.TB so this helper can stay decoupled
+// from the testing package while still surfacing fatal errors to the caller.
+type require interface {
+	Fatalf(format string, args ...any)
 }

--- a/pkg/detect/ospkg/base/base_test.go
+++ b/pkg/detect/ospkg/base/base_test.go
@@ -455,7 +455,7 @@ func TestDetect(t *testing.T) {
 					t.Errorf("Detect() error mismatch: want %v, got %v", tt.wantErr, err)
 				}
 			default:
-				if diff := cmp.Diff(tt.want, got); diff != "" {
+				if diff := cmp.Diff(tt.want, test.FilterAffected(t, got)); diff != "" {
 					t.Errorf("Detect() (-expected +got):\n%s", diff)
 				}
 			}

--- a/pkg/detect/ospkg/base/base_test.go
+++ b/pkg/detect/ospkg/base/base_test.go
@@ -425,7 +425,94 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
-			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+			// util.Detect now passes every condition through unconditionally;
+			// the repository mismatch fails Criteria.Affected() but is no
+			// longer pruned at this layer (the top-level pkg/detect.Detect
+			// applies the gate). The FilteredCondition shape matches the
+			// "matching repository" case above.
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"RHSA-2022:5214": {
+					Ecosystem: ecosystemTypes.Ecosystem(fmt.Sprintf("%s:9", ecosystemTypes.EcosystemTypeRedHat)),
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						sourceTypes.RedHatOVALv2: {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator:     criteriaTypes.CriteriaOperatorTypeAND,
+									Repositories: []string{"rhel-9-for-ppc64le-baseos-rpms", "rhel-9-for-x86_64-baseos-rpms"},
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeOR,
+											Criterias: []criteriaTypes.FilteredCriteria{
+												{
+													Operator: criteriaTypes.CriteriaOperatorTypeAND,
+													Criterions: []criterionTypes.FilteredCriterion{
+														{
+															Criterion: criterionTypes.Criterion{
+																Type: criterionTypes.CriterionTypeVersion,
+																Version: &vcTypes.Criterion{
+																	Vulnerable: true,
+																	FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+																	Package: vcPackageTypes.Package{
+																		Type: vcPackageTypes.PackageTypeBinary,
+																		Binary: &vcBinaryPackageTypes.Package{
+																			Name:          "kpatch-patch-5_14_0-70_13_1",
+																			Architectures: []string{"ppc64le", "x86_64"},
+																		},
+																	},
+																	Affected: &vcAffectedTypes.Affected{
+																		Type:  vcAffectedRangeTypes.RangeTypeRPM,
+																		Range: []vcAffectedRangeTypes.Range{{LessThan: "0:1-1.el9_0"}},
+																		Fixed: []string{"0:1-1.el9_0"},
+																	},
+																},
+															},
+															Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+														},
+													},
+												},
+											},
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeNoneExist,
+														NoneExist: &necTypes.Criterion{
+															Type:   necTypes.PackageTypeBinary,
+															Binary: &necBinaryPackageTypes.Package{Name: "kpatch-patch-5_14_0-70_13_1"},
+														},
+													},
+													Accepts: criterionTypes.AcceptQueries{NoneExist: true},
+												},
+											},
+										},
+									},
+									Criterions: []criterionTypes.FilteredCriterion{
+										{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Package: vcPackageTypes.Package{
+														Type: vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{
+															Name:          "kernel",
+															Architectures: []string{"ppc64le", "x86_64"},
+														},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeRPM,
+														Range: []vcAffectedRangeTypes.Range{{Equal: "0:5.14.0-70.13.1.el9_0"}},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("rhel-9-including-unpatched"),
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -455,7 +542,7 @@ func TestDetect(t *testing.T) {
 					t.Errorf("Detect() error mismatch: want %v, got %v", tt.wantErr, err)
 				}
 			default:
-				if diff := cmp.Diff(tt.want, test.FilterAffected(t, got)); diff != "" {
+				if diff := cmp.Diff(tt.want, got); diff != "" {
 					t.Errorf("Detect() (-expected +got):\n%s", diff)
 				}
 			}

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -159,7 +159,70 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
-			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+			// util.Detect passes every condition through; the per-condition
+			// Affected gate moved to pkg/detect.Detect. Both KB criteria are
+			// returned with zero-value Accepts (the scan only reports Applied,
+			// so neither Unapplied nor Covered matched).
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2021-1640": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 2004 for x64-based Systems",
+															KBID:    "5000802",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
+				"CVE-2021-26413": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 2004 for x64-based Systems",
+															KBID:    "5001330",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "fix KB covered by applied superseding KB, no detection",
@@ -181,7 +244,69 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
-			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+			// Same shape as the "all KBs applied" case: util.Detect emits the
+			// raw conditions with empty Accepts; the top-level filter in
+			// pkg/detect.Detect prunes them via Criteria.Affected().
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2021-1640": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 2004 for x64-based Systems",
+															KBID:    "5000802",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
+				"CVE-2021-26413": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 2004 for x64-based Systems",
+															KBID:    "5001330",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "supersession auto-discovery from applied KB",
@@ -202,7 +327,40 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
+			// CVE-2021-26413's 5001330 condition is "Covered" by the applied
+			// 5000802 (supersession chain). CVE-2021-1640's 5000802 condition
+			// is the applied KB itself; util.Detect now emits it with empty
+			// Accepts so the top-level filter can drop it.
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2021-1640": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 2004 for x64-based Systems",
+															KBID:    "5000802",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 2004 for x64-based Systems"),
+							},
+						},
+					},
+				},
 				"CVE-2021-26413": {
 					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
 					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
@@ -310,7 +468,47 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
-			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+			// Edge 98.x is above the fixed range; util.Detect still emits
+			// the version criterion (with empty Accepts.Version, i.e. no
+			// matching query index) and pkg/detect.Detect prunes it.
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2022-0096": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterions: []criterionTypes.FilteredCriterion{
+										{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type: vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{
+															Name: "Microsoft Edge (Chromium-based)",
+														},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeMicrosoftEdge,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "97.0.1072.55"}},
+														Fixed: []string{"97.0.1072.55"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Microsoft Edge (Chromium-based)"),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "detect CVE-2022-21907 by Release and Kernel.Version",
@@ -406,7 +604,56 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
-			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+			// Patched kernel is at the fix; util.Detect emits the version
+			// criterion + KB criterion with empty Accepts and the top-level
+			// filter drops them.
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				"CVE-2022-21907": {
+					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						"microsoft-cvrf": {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterions: []criterionTypes.FilteredCriterion{
+										{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeVersion,
+												Version: &vcTypes.Criterion{
+													Vulnerable: true,
+													FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassFixed},
+													Package: vcPackageTypes.Package{
+														Type: vcPackageTypes.PackageTypeBinary,
+														Binary: &vcBinaryPackageTypes.Package{
+															Name: "Windows 10 Version 21H2 for x64-based Systems",
+														},
+													},
+													Affected: &vcAffectedTypes.Affected{
+														Type:  vcAffectedRangeTypes.RangeTypeMicrosoftWindows,
+														Range: []vcAffectedRangeTypes.Range{{LessThan: "10.0.19044.1466"}},
+														Fixed: []string{"10.0.19044.1466"},
+													},
+												},
+											},
+											Accepts: criterionTypes.AcceptQueries{Version: []int{}},
+										},
+										{
+											Criterion: criterionTypes.Criterion{
+												Type: criterionTypes.CriterionTypeKB,
+												KB: &kbcTypes.Criterion{
+													Product: "Windows 10 Version 21H2 for x64-based Systems",
+													KBID:    "5009543",
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 21H2 for x64-based Systems"),
+							},
+						},
+					},
+				},
+			},
 		},
 		{
 			name:    "detect bare cross-platform app KB criterion on Windows host",
@@ -479,6 +726,11 @@ func TestDetect(t *testing.T) {
 				},
 				concurrency: 1,
 			},
+			// util.Detect emits one condition per OS-segment tag; the host's
+			// release matches only "Windows 10 Version 21H2 for x64-based
+			// Systems" so the cross-product Server 2012 R2 / ARM64 conditions
+			// come through with empty Accepts and pkg/detect.Detect drops
+			// them.
 			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
 				"CVE-2024-90001": {
 					Ecosystem: ecosystemTypes.EcosystemTypeMicrosoft,
@@ -506,6 +758,28 @@ func TestDetect(t *testing.T) {
 									},
 								},
 								Tag: segmentTypes.DetectionTag("Windows 10 Version 21H2 for x64-based Systems"),
+							},
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows Server 2012 R2",
+															KBID:    "9000001",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows Server 2012 R2"),
 							},
 						},
 					},
@@ -536,6 +810,28 @@ func TestDetect(t *testing.T) {
 									},
 								},
 								Tag: segmentTypes.DetectionTag("Windows 10 Version 21H2 for x64-based Systems"),
+							},
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeAND,
+											Criterions: []criterionTypes.FilteredCriterion{
+												{
+													Criterion: criterionTypes.Criterion{
+														Type: criterionTypes.CriterionTypeKB,
+														KB: &kbcTypes.Criterion{
+															Product: "Windows 10 Version 21H2 for ARM64-based Systems",
+															KBID:    "9000002",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+								Tag: segmentTypes.DetectionTag("Windows 10 Version 21H2 for ARM64-based Systems"),
 							},
 						},
 					},
@@ -570,7 +866,7 @@ func TestDetect(t *testing.T) {
 					t.Errorf("Detect() error mismatch: want %v, got %v", tt.wantErr, err)
 				}
 			default:
-				if diff := cmp.Diff(tt.want, test.FilterAffected(t, got)); diff != "" {
+				if diff := cmp.Diff(tt.want, got); diff != "" {
 					t.Errorf("Detect() (-expected +got):\n%s", diff)
 				}
 			}

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -141,7 +141,7 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			name:    "all KBs applied, no detection",
+			name:    "all KBs applied: lower-level emits unaffected KB conditions",
 			fixture: "testdata/fixtures/microsoft-supersession",
 			config: session.Config{
 				Type:    "boltdb",
@@ -225,7 +225,7 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			name:    "fix KB covered by applied superseding KB, no detection",
+			name:    "fix KB covered by applied superseding KB: lower-level emits unaffected KB conditions",
 			fixture: "testdata/fixtures/microsoft-supersession",
 			config: session.Config{
 				Type:    "boltdb",
@@ -451,7 +451,7 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			name:    "Edge version not affected, no detection",
+			name:    "Edge version above fix: lower-level emits unaffected version condition",
 			fixture: "testdata/fixtures/microsoft-edge",
 			config: session.Config{
 				Type:    "boltdb",
@@ -582,7 +582,7 @@ func TestDetect(t *testing.T) {
 			},
 		},
 		{
-			name:    "Windows version patched, no detection",
+			name:    "Windows version at fix: lower-level emits unaffected conditions",
 			fixture: "testdata/fixtures/microsoft-windows-version",
 			config: session.Config{
 				Type:    "boltdb",

--- a/pkg/detect/ospkg/microsoft/microsoft_test.go
+++ b/pkg/detect/ospkg/microsoft/microsoft_test.go
@@ -570,7 +570,7 @@ func TestDetect(t *testing.T) {
 					t.Errorf("Detect() error mismatch: want %v, got %v", tt.wantErr, err)
 				}
 			default:
-				if diff := cmp.Diff(tt.want, got); diff != "" {
+				if diff := cmp.Diff(tt.want, test.FilterAffected(t, got)); diff != "" {
 					t.Errorf("Detect() (-expected +got):\n%s", diff)
 				}
 			}

--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -67,7 +67,7 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, queries []str
 					}
 
 					// Pass every condition through unconditionally. The
-					// per-condition Affected/unaffected gating is moved to the
+					// per-condition affected/unaffected gating is moved to the
 					// top-level pkg/detect.Detect, so that consumers calling
 					// this function directly (or via ospkg.Detect / cpe.Detect)
 					// can apply their own pruning / ecosystem-specific filter

--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -72,16 +72,6 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, queries []str
 					// this function directly (or via ospkg.Detect / cpe.Detect)
 					// can apply their own pruning / ecosystem-specific filter
 					// over the full FilteredCriteria tree.
-					//
-					// Still invoke Affected() purely for its validation side
-					// effect — it walks the criteria tree and rejects
-					// malformed operator/type values, preserving the old
-					// fail-fast behavior at this layer. The boolean is
-					// intentionally discarded.
-					if _, err := fcond.Affected(); err != nil {
-						return errors.Wrap(err, "condition affected")
-					}
-
 					fcond.Criteria, err = replaceIndexes(fcond.Criteria, req.Indexes)
 					if err != nil {
 						return errors.Wrap(err, "replace indexes")

--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -72,6 +72,16 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, queries []str
 					// this function directly (or via ospkg.Detect / cpe.Detect)
 					// can apply their own pruning / ecosystem-specific filter
 					// over the full FilteredCriteria tree.
+					//
+					// Still invoke Affected() purely for its validation side
+					// effect — it walks the criteria tree and rejects
+					// malformed operator/type values, preserving the old
+					// fail-fast behavior at this layer. The boolean is
+					// intentionally discarded.
+					if _, err := fcond.Affected(); err != nil {
+						return errors.Wrap(err, "condition affected")
+					}
+
 					fcond.Criteria, err = replaceIndexes(fcond.Criteria, req.Indexes)
 					if err != nil {
 						return errors.Wrap(err, "replace indexes")

--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -66,26 +66,26 @@ func Detect(s session.Storage, ecosystem ecosystemTypes.Ecosystem, queries []str
 						return errors.Wrap(err, "criteria accept")
 					}
 
-					isAffected, err := fcond.Affected()
+					// Pass every condition through unconditionally. The
+					// per-condition Affected/unaffected gating is moved to the
+					// top-level pkg/detect.Detect, so that consumers calling
+					// this function directly (or via ospkg.Detect / cpe.Detect)
+					// can apply their own pruning / ecosystem-specific filter
+					// over the full FilteredCriteria tree.
+					fcond.Criteria, err = replaceIndexes(fcond.Criteria, req.Indexes)
 					if err != nil {
-						return errors.Wrap(err, "criteria affected")
+						return errors.Wrap(err, "replace indexes")
 					}
-					if isAffected {
-						fcond.Criteria, err = replaceIndexes(fcond.Criteria, req.Indexes)
-						if err != nil {
-							return errors.Wrap(err, "replace indexes")
-						}
 
-						d, ok := dm[req.RootID]
-						if !ok {
-							d = detectTypes.VulnerabilityDataDetection{
-								Ecosystem: ecosystem,
-								Contents:  make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition),
-							}
+					d, ok := dm[req.RootID]
+					if !ok {
+						d = detectTypes.VulnerabilityDataDetection{
+							Ecosystem: ecosystem,
+							Contents:  make(map[sourceTypes.SourceID][]conditionTypes.FilteredCondition),
 						}
-						d.Contents[sourceID] = append(d.Contents[sourceID], fcond)
-						dm[req.RootID] = d
 					}
+					d.Contents[sourceID] = append(d.Contents[sourceID], fcond)
+					dm[req.RootID] = d
 				}
 			}
 


### PR DESCRIPTION
## Summary

- `pkg/detect/util/detect.go` now passes every condition through unconditionally. The per-condition `Affected()` gate moves up to `pkg/detect.Detect`, so consumers that call the lower-level functions (`ospkg.Detect`, `cpe.Detect`, `util.Detect`) receive the full `FilteredCriteria` tree and can apply their own pruning / ecosystem-specific filter.
- A new `filterAffected` helper in `pkg/detect/detect.go` reproduces the previous public semantics: it drops conditions whose `FilteredCriteria` evaluates as not-affected and prunes empty `Detections` / `VulnerabilityData` entries. Covered by a focused table-driven `TestFilterAffected` (empty input, affected/unaffected, per-source pruning, multi-detection pruning, error surfacing).
- Existing `ospkg/base` and `ospkg/microsoft` table-driven tests have their `want` goldens updated to include the unaffected conditions the lower-level `Detect` now returns (KB criteria with empty `Accepts`, version criteria with empty `Version` index slice, cross-product sibling conditions sharing the same OS-segment tag, etc.). No test helper that filters before comparison — the goldens reflect what the functions actually emit.

## Motivation

The original gate in `util.Detect` short-circuited not-affected conditions before downstream consumers could see them. That made it impossible to apply ecosystem-specific relaxation (e.g. treating an `AND` of `[vulnerable product] AND [env]` as affected when the env CPE is absent, which is how `go-cve-dictionary` matches today). Moving the gate up keeps the default `pkg/detect.Detect` pipeline byte-identical for callers, while letting alternative pipelines opt out.

## Compatibility with vuls/

[future-architect/vuls](https://github.com/future-architect/vuls) (vuls0) calls `ospkg.Detect` directly from [detector/vuls2/vuls2.go:216](https://github.com/future-architect/vuls/blob/259e69444d66cc695ad0ce5e76425148970ada48/detector/vuls2/vuls2.go#L216) and does **not** go through `pkg/detect.Detect`. Its own `pruneCriteria` / `walkCriteria` already handles unaffected conditions correctly, so **no changes are required on the vuls0 side**.

Verified end-to-end with the `integration/data/results/` fixtures: ran both v0.39.2 release (old vuls2: filtering in `util.Detect`) and a vuls/ master binary linked against this branch (new vuls2: passthrough) against the same `vuls.db` on 7 OS fixtures (rhel_80/90/10, ubuntu_2204/2404, amazon_2/2023), two passes with target/binary order swapped. Detection JSON byte-identical in all 14 runs after deep array sort + build-metadata strip. Wall-clock and max RSS within noise; user CPU on the workspace binary is ~3–8 % higher because `filterAffected` walks every condition once more, as expected.

## Test plan

- [x] `GOEXPERIMENT=jsonv2 go test ./...` (vuls2 nightly + this branch) — all PASS, including the new `TestFilterAffected`
- [x] `GOEXPERIMENT=jsonv2 go test ./...` against [future-architect/vuls](https://github.com/future-architect/vuls) at commit `259e6944` with this branch overlaid via `go.work` — all PASS (the scanner package needs `git submodule update --init integration` first; see `integration/data/lockfile`)
- [x] End-to-end detection equivalence vs v0.39.2 across 7 OS fixtures (see "Compatibility with vuls/")

🤖 Generated with [Claude Code](https://claude.com/claude-code)