### PR TITLE
feat!(db/detect): index CPE detections by part:vendor:product

### DIFF
--- a/pkg/db/session/internal/boltdb/boltdb_test.go
+++ b/pkg/db/session/internal/boltdb/boltdb_test.go
@@ -463,6 +463,32 @@ func TestConnection_Put(t *testing.T) {
 				"datasource -> source-b":                  []byte(`{"id":"source-b","name":"Source B","raw":[{"url":"ghcr.io/vulsio/source-b"}]}`),
 			},
 		},
+		{
+			name: "cpe",
+			fields: fields{
+				Config: &boltdb.Config{Path: filepath.Join(t.TempDir(), "vuls.db")},
+			},
+			args: args{
+				roots: []string{"testdata/fixtures/nvd-cpe/nvd-feed-cve-v2"},
+			},
+			want: map[string][]byte{
+				"metadata":                                        nil,
+				"metadata -> db":                                  fmt.Appendf(nil, `{"schema_version":0,"created_by":"vuls (devel)","last_modified":"%s"}`, time.Now().UTC().Format(time.RFC3339Nano)),
+				"vulnerability":                                   nil,
+				"vulnerability -> root":                           nil,
+				"vulnerability -> root -> CVE-2024-0028":          []byte(`{"id":"CVE-2024-0028","vulnerabilities":["CVE-2024-0028"],"ecosystems":["cpe"],"data_sources":["nvd-feed-cve-v2"]}`),
+				"vulnerability -> advisory":                       nil,
+				"vulnerability -> vulnerability":                  nil,
+				"vulnerability -> vulnerability -> CVE-2024-0028": []byte(`{"nvd-feed-cve-v2":{"CVE-2024-0028":[{"content":{"id":"CVE-2024-0028","description":"In Audio Service, there is a possible way to obtain MAC addresses of nearby Bluetooth devices due to a missing permission check. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.","severity":[{"type":"cvss_v31","source":"134c704f-9b21-4f2e-91b3-4a467353bcc0","cvss_v31":{"vector":"CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N","base_score":5.5,"base_severity":"MEDIUM","temporal_score":5.5,"temporal_severity":"MEDIUM","environmental_score":5.5,"environmental_severity":"MEDIUM"}}],"cwe":[{"source":"134c704f-9b21-4f2e-91b3-4a467353bcc0","cwe":["CWE-862"]}],"references":[{"source":"nvd.nist.gov","url":"https://nvd.nist.gov/vuln/detail/CVE-2024-0028"},{"source":"security@android.com","url":"https://source.android.com/security/bulletin/android-16"}],"published":"2025-09-05T17:15:33.27Z","modified":"2025-09-08T16:38:34.34Z"},"segments":[{"ecosystem":"cpe"}]}]}}`),
+				"cpe":                               nil,
+				"cpe -> detection":                  nil,
+				"cpe -> detection -> CVE-2024-0028": []byte(`{"nvd-feed-cve-v2":[{"criteria":{"operator":"OR","criterias":[{"operator":"OR","criterias":[{"operator":"OR","criterias":[{"operator":"OR","criterions":[{"type":"cpe","cpe":{"vulnerable":true,"fix_status":{"class":"unknown"},"cpe":"cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*"}}]}]}]}]}}]}`),
+				"cpe -> index":                      nil,
+				"cpe -> index -> o:google:android":  []byte(`["CVE-2024-0028"]`),
+				"datasource":                        nil,
+				"datasource -> nvd-feed-cve-v2":     []byte(`{"id":"nvd-feed-cve-v2","name":"NVD Feed CVE v2"}`),
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/db/session/internal/boltdb/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/data/2024/CVE-2024-0028.json
+++ b/pkg/db/session/internal/boltdb/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/data/2024/CVE-2024-0028.json
@@ -1,0 +1,96 @@
+{
+	"id": "CVE-2024-0028",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-0028",
+				"description": "In Audio Service, there is a possible way to obtain MAC addresses of nearby Bluetooth devices due to a missing permission check. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+						"cwe": [
+							"CWE-862"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "nvd.nist.gov",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0028"
+					},
+					{
+						"source": "security@android.com",
+						"url": "https://source.android.com/security/bulletin/android-16"
+					}
+				],
+				"published": "2025-09-05T17:15:33.27Z",
+				"modified": "2025-09-08T16:38:34.34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterias": [
+											{
+												"operator": "OR",
+												"criterions": [
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*"
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nvd-feed-cve-v2",
+		"raws": [
+			"vuls-data-raw-nvd-feed-cve-v2/2024/CVE-2024-0028.json"
+		]
+	}
+}

--- a/pkg/db/session/internal/boltdb/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/datasource.json
+++ b/pkg/db/session/internal/boltdb/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "nvd-feed-cve-v2",
+	"name": "NVD Feed CVE v2"
+}

--- a/pkg/db/session/internal/util/util.go
+++ b/pkg/db/session/internal/util/util.go
@@ -65,7 +65,7 @@ func WalkCriteria(ca criteriaTypes.Criteria) ([]string, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "unbind %q", string(cn.CPE.CPE))
 			}
-			pkgs = append(pkgs, fmt.Sprintf("%s:%s", wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct)))
+			pkgs = append(pkgs, fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct)))
 		default:
 			return nil, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []criterionTypes.CriterionType{criterionTypes.CriterionTypeVersion, criterionTypes.CriterionTypeNoneExist, criterionTypes.CriterionTypeKB, criterionTypes.CriterionTypeCPE}, cn.Type)
 		}

--- a/pkg/db/session/internal/util/util_test.go
+++ b/pkg/db/session/internal/util/util_test.go
@@ -232,7 +232,7 @@ func TestWalkCriteria(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"cisco:unified_communications_manager", "vendor:product"},
+			want: []string{"a:cisco:unified_communications_manager", "a:vendor:product"},
 		},
 		{
 			name: "kb",

--- a/pkg/detect/cpe/cpe.go
+++ b/pkg/detect/cpe/cpe.go
@@ -30,7 +30,7 @@ func Detect(s session.Storage, sr scanTypes.ScanResult, concurrency int) (map[da
 		if err != nil {
 			return nil, errors.Wrapf(err, "unbind %q to WFN", cpe)
 		}
-		qm[fmt.Sprintf("%s:%s", wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))] = append(qm[fmt.Sprintf("%s:%s", wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))], i)
+		qm[fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))] = append(qm[fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))], i)
 	}
 
 	dm, err := util.Detect(s, ecosystemTypes.EcosystemTypeCPE, slices.Collect(maps.Keys(qm)), func(rootID dataTypes.RootID, queries []string) util.Request {

--- a/pkg/detect/cpe/cpe.go
+++ b/pkg/detect/cpe/cpe.go
@@ -30,7 +30,8 @@ func Detect(s session.Storage, sr scanTypes.ScanResult, concurrency int) (map[da
 		if err != nil {
 			return nil, errors.Wrapf(err, "unbind %q to WFN", cpe)
 		}
-		qm[fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))] = append(qm[fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))], i)
+		key := fmt.Sprintf("%s:%s:%s", wfn.GetString(common.AttributePart), wfn.GetString(common.AttributeVendor), wfn.GetString(common.AttributeProduct))
+		qm[key] = append(qm[key], i)
 	}
 
 	dm, err := util.Detect(s, ecosystemTypes.EcosystemTypeCPE, slices.Collect(maps.Keys(qm)), func(rootID dataTypes.RootID, queries []string) util.Request {

--- a/pkg/detect/cpe/cpe_test.go
+++ b/pkg/detect/cpe/cpe_test.go
@@ -136,6 +136,7 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("open db connection. error = %v", err)
 			}
 			defer s.Storage().Close()
+			defer s.Cache().Close()
 
 			got, err := cpe.Detect(s.Storage(), tt.args.sr, tt.args.concurrency)
 			if (err != nil) != tt.wantErr {

--- a/pkg/detect/cpe/cpe_test.go
+++ b/pkg/detect/cpe/cpe_test.go
@@ -1,0 +1,150 @@
+package cpe_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.etcd.io/bbolt"
+
+	dataTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data"
+	conditionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition"
+	criteriaTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria"
+	criterionTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion"
+	ccTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/cpecriterion"
+	vcFixStatusTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/condition/criteria/criterion/versioncriterion/fixstatus"
+	ecosystemTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/data/detection/segment/ecosystem"
+	sourceTypes "github.com/MaineK00n/vuls-data-update/pkg/extract/types/source"
+	"github.com/MaineK00n/vuls2/pkg/db/session"
+	"github.com/MaineK00n/vuls2/pkg/detect/cpe"
+	"github.com/MaineK00n/vuls2/pkg/detect/internal/test"
+	detectTypes "github.com/MaineK00n/vuls2/pkg/detect/types"
+	scanTypes "github.com/MaineK00n/vuls2/pkg/scan/types"
+)
+
+func TestDetect(t *testing.T) {
+	type args struct {
+		sr          scanTypes.ScanResult
+		concurrency int
+	}
+	tests := []struct {
+		name    string
+		fixture string
+		config  session.Config
+		args    args
+		want    map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection
+		wantErr bool
+	}{
+		{
+			name:    "no cpe in scan result",
+			fixture: "testdata/fixtures/nvd-cpe",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				sr:          scanTypes.ScanResult{},
+				concurrency: 1,
+			},
+			want: nil,
+		},
+		{
+			// Same vendor:product but part "a" instead of "o" must not match the
+			// indexed key "o:google:android" — guards the part:vendor:product key.
+			name:    "miss: part differs",
+			fixture: "testdata/fixtures/nvd-cpe",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				sr:          scanTypes.ScanResult{CPE: []string{"cpe:2.3:a:google:android:16.0:*:*:*:*:*:*:*"}},
+				concurrency: 1,
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{},
+		},
+		{
+			name:    "hit: part:vendor:product matches",
+			fixture: "testdata/fixtures/nvd-cpe",
+			config: session.Config{
+				Type:    "boltdb",
+				Path:    filepath.Join(t.TempDir(), "vuls.db"),
+				Options: session.StorageOptions{BoltDB: bbolt.DefaultOptions},
+			},
+			args: args{
+				sr:          scanTypes.ScanResult{CPE: []string{"cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*"}},
+				concurrency: 1,
+			},
+			want: map[dataTypes.RootID]detectTypes.VulnerabilityDataDetection{
+				dataTypes.RootID("CVE-2024-0028"): {
+					Ecosystem: ecosystemTypes.EcosystemTypeCPE,
+					Contents: map[sourceTypes.SourceID][]conditionTypes.FilteredCondition{
+						sourceTypes.NVDFeedCVEv2: {
+							{
+								Criteria: criteriaTypes.FilteredCriteria{
+									Operator: criteriaTypes.CriteriaOperatorTypeOR,
+									Criterias: []criteriaTypes.FilteredCriteria{
+										{
+											Operator: criteriaTypes.CriteriaOperatorTypeOR,
+											Criterias: []criteriaTypes.FilteredCriteria{
+												{
+													Operator: criteriaTypes.CriteriaOperatorTypeOR,
+													Criterias: []criteriaTypes.FilteredCriteria{
+														{
+															Operator: criteriaTypes.CriteriaOperatorTypeOR,
+															Criterions: []criterionTypes.FilteredCriterion{
+																{
+																	Criterion: criterionTypes.Criterion{
+																		Type: criterionTypes.CriterionTypeCPE,
+																		CPE: &ccTypes.Criterion{
+																			Vulnerable: true,
+																			FixStatus:  &vcFixStatusTypes.FixStatus{Class: vcFixStatusTypes.ClassUnknown},
+																			CPE:        "cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*",
+																		},
+																	},
+																	Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := test.PopulateDB(tt.config, tt.fixture); err != nil {
+				t.Fatalf("populate db. error = %v", err)
+			}
+
+			s, err := tt.config.New()
+			if err != nil {
+				t.Fatalf("new session. error = %v", err)
+			}
+
+			if err := s.Storage().Open(); err != nil {
+				t.Fatalf("open db connection. error = %v", err)
+			}
+			defer s.Storage().Close()
+
+			got, err := cpe.Detect(s.Storage(), tt.args.sr, tt.args.concurrency)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Detect() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("Detect() (-expected +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/detect/cpe/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/data/2024/CVE-2024-0028.json
+++ b/pkg/detect/cpe/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/data/2024/CVE-2024-0028.json
@@ -1,0 +1,96 @@
+{
+	"id": "CVE-2024-0028",
+	"vulnerabilities": [
+		{
+			"content": {
+				"id": "CVE-2024-0028",
+				"description": "In Audio Service, there is a possible way to obtain MAC addresses of nearby Bluetooth devices due to a missing permission check. This could lead to local escalation of privilege with no additional execution privileges needed. User interaction is not needed for exploitation.",
+				"severity": [
+					{
+						"type": "cvss_v31",
+						"source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+						"cvss_v31": {
+							"vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+							"base_score": 5.5,
+							"base_severity": "MEDIUM",
+							"temporal_score": 5.5,
+							"temporal_severity": "MEDIUM",
+							"environmental_score": 5.5,
+							"environmental_severity": "MEDIUM"
+						}
+					}
+				],
+				"cwe": [
+					{
+						"source": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+						"cwe": [
+							"CWE-862"
+						]
+					}
+				],
+				"references": [
+					{
+						"source": "nvd.nist.gov",
+						"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0028"
+					},
+					{
+						"source": "security@android.com",
+						"url": "https://source.android.com/security/bulletin/android-16"
+					}
+				],
+				"published": "2025-09-05T17:15:33.27Z",
+				"modified": "2025-09-08T16:38:34.34Z"
+			},
+			"segments": [
+				{
+					"ecosystem": "cpe"
+				}
+			]
+		}
+	],
+	"detections": [
+		{
+			"ecosystem": "cpe",
+			"conditions": [
+				{
+					"criteria": {
+						"operator": "OR",
+						"criterias": [
+							{
+								"operator": "OR",
+								"criterias": [
+									{
+										"operator": "OR",
+										"criterias": [
+											{
+												"operator": "OR",
+												"criterions": [
+													{
+														"type": "cpe",
+														"cpe": {
+															"vulnerable": true,
+															"fix_status": {
+																"class": "unknown"
+															},
+															"cpe": "cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*"
+														}
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"data_source": {
+		"id": "nvd-feed-cve-v2",
+		"raws": [
+			"vuls-data-raw-nvd-feed-cve-v2/2024/CVE-2024-0028.json"
+		]
+	}
+}

--- a/pkg/detect/cpe/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/datasource.json
+++ b/pkg/detect/cpe/testdata/fixtures/nvd-cpe/nvd-feed-cve-v2/datasource.json
@@ -1,0 +1,4 @@
+{
+	"id": "nvd-feed-cve-v2",
+	"name": "NVD Feed CVE v2"
+}

--- a/pkg/detect/ospkg/ospkg_test.go
+++ b/pkg/detect/ospkg/ospkg_test.go
@@ -181,6 +181,7 @@ func TestDetect(t *testing.T) {
 				t.Fatalf("open: %v", err)
 			}
 			defer s.Storage().Close()
+			defer s.Cache().Close()
 
 			got, err := ospkg.Detect(s.Storage(), tt.args.sr, tt.args.concurrency)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
## What

Change the CPE detection index key from `vendor:product` to `part:vendor:product` on both the db add and detect sides, so the ecosystem index distinguishes CPE part (e.g. `a` / `o` / `h`).

## Changes

- **db add**: [`WalkCriteria`](pkg/db/session/internal/util/util.go) now prefixes the CPE part attribute when building the index key for CPE criterions.
- **detect**: [`cpe.Detect`](pkg/detect/cpe/cpe.go) builds its lookup query map with the matching `part:vendor:product` key.
- **tests**:
  - Updated `TestWalkCriteria`'s `cpe` golden to the new format (`a:cisco:unified_communications_manager`, `a:vendor:product`).
  - Added a `cpe` case to `TestConnection_Put` with a CPE detection fixture adapted from [vuls-data-update#827](https://github.com/MaineK00n/vuls-data-update/pull/827)'s nvd-feed-cve-v2 golden, asserting the index is keyed `o:google:android`.

## Notes

This is a breaking DB layout change (`!`): the on-disk CPE index key format changes, so add and detect must be on the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)