### PR TITLE
chore(db): rename mitre-v5 extracted repo ref to mitre-cve-v5

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -56,7 +56,7 @@ db-build:
 	make db-add REPO=vuls-data-extracted-epss BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	make db-add REPO=vuls-data-extracted-fedora BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	make db-add REPO=vuls-data-extracted-freebsd BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
-	make db-add REPO=vuls-data-extracted-mitre-v5 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
+	make db-add REPO=vuls-data-extracted-mitre-cve-v5 BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	make db-add REPO=vuls-data-extracted-nvd-api-cve BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	make db-add REPO=vuls-data-extracted-oracle-linux BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}
 	make db-add REPO=vuls-data-extracted-redhat-vex-rhel BRANCH=${BRANCH} DBTYPE=${DBTYPE} DBPATH=${DBPATH}


### PR DESCRIPTION
## What
Follow the `vuls-data-update` / `vuls-data-db` source id rename in the local `GNUmakefile` `db-build` target: `vuls-data-extracted-mitre-v5` → `vuls-data-extracted-mitre-cve-v5`.

## Why
Keeps the dev DB build pointing at the renamed GHCR package.

Depends on MaineK00n/vuls-data-update#846 and vulsio/vuls-data-db#170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)