### PR TITLE
refactor(detect): adopt categorized CPE accept queries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/MaineK00n/vuls2
 go 1.26
 
 require (
-	github.com/MaineK00n/vuls-data-update v0.0.0-20260608045703-08681989ac97
+	github.com/MaineK00n/vuls-data-update v0.0.0-20260618100055-bfedbc246360
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/glebarez/sqlite v1.11.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ filippo.io/edwards25519 v1.1.1/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc h1:ZeayjCT6JMMfoL9cS3w1BvBogxRi+I3QmabI8jL7+HQ=
 github.com/MaineK00n/go-microsoft-version v0.0.0-20260325021654-1d9206bdeffc/go.mod h1:GNf+Vhnxk8/pW56jsxAeFCBP0VCgVQlLIJ812UnAj9c=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260608045703-08681989ac97 h1:DiJcZ2M0WT3Yr3vaADS3pcfR35o9344eoVzBDg29uKk=
-github.com/MaineK00n/vuls-data-update v0.0.0-20260608045703-08681989ac97/go.mod h1:xvEPdYhcruMCrwAMEgbqCqZ5t+HLH6Ckn4jaEx59Uic=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260618100055-bfedbc246360 h1:JECQZ+ylQ3phdIPtsX1RBGjWSYCqJUjQeNS1vrQl1eA=
+github.com/MaineK00n/vuls-data-update v0.0.0-20260618100055-bfedbc246360/go.mod h1:xvEPdYhcruMCrwAMEgbqCqZ5t+HLH6Ckn4jaEx59Uic=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/aquasecurity/go-gem-version v0.0.0-20201115065557-8eed6fe000ce h1:QgBRgJvtEOBtUXilDb1MLi1p1MWoyFDXAu5DEUl5nwM=

--- a/pkg/detect/cpe/cpe_test.go
+++ b/pkg/detect/cpe/cpe_test.go
@@ -104,7 +104,7 @@ func TestDetect(t *testing.T) {
 																			CPE:        "cpe:2.3:o:google:android:16.0:*:*:*:*:*:*:*",
 																		},
 																	},
-																	Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+																	Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{0}, VersionUnconfirmed: []int{}}},
 																},
 															},
 														},

--- a/pkg/detect/util/detect.go
+++ b/pkg/detect/util/detect.go
@@ -141,11 +141,16 @@ func replaceIndexes(fca criteriaTypes.FilteredCriteria, indexes []int) (criteria
 		case criterionTypes.CriterionTypeKB:
 			replaced.Criterions = append(replaced.Criterions, cn)
 		case criterionTypes.CriterionTypeCPE:
-			is := make([]int, 0, len(cn.Accepts.CPE))
-			for _, a := range cn.Accepts.CPE {
-				is = append(is, indexes[a])
+			exact := make([]int, 0, len(cn.Accepts.CPE.Exact))
+			for _, a := range cn.Accepts.CPE.Exact {
+				exact = append(exact, indexes[a])
 			}
-			cn.Accepts.CPE = is
+			cn.Accepts.CPE.Exact = exact
+			versionUnconfirmed := make([]int, 0, len(cn.Accepts.CPE.VersionUnconfirmed))
+			for _, a := range cn.Accepts.CPE.VersionUnconfirmed {
+				versionUnconfirmed = append(versionUnconfirmed, indexes[a])
+			}
+			cn.Accepts.CPE.VersionUnconfirmed = versionUnconfirmed
 			replaced.Criterions = append(replaced.Criterions, cn)
 		default:
 			return criteriaTypes.FilteredCriteria{}, errors.Errorf("unexpected criterion type. expected: %q, actual: %q", []criterionTypes.CriterionType{criterionTypes.CriterionTypeVersion, criterionTypes.CriterionTypeNoneExist, criterionTypes.CriterionTypeKB, criterionTypes.CriterionTypeCPE}, cn.Criterion.Type)

--- a/pkg/detect/util/detect_test.go
+++ b/pkg/detect/util/detect_test.go
@@ -763,7 +763,7 @@ func Test_replaceIndexes(t *testing.T) {
 									CPE: "cpe:2.3:a:vendor:pkg1:*:*:*:*:*:*:*:*",
 								},
 							},
-							Accepts: criterionTypes.AcceptQueries{CPE: []int{0}},
+							Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{0}, VersionUnconfirmed: []int{1}}},
 						},
 					},
 				},
@@ -779,7 +779,7 @@ func Test_replaceIndexes(t *testing.T) {
 								CPE: "cpe:2.3:a:vendor:pkg0:*:*:*:*:*:*:*:*",
 							},
 						},
-						Accepts: criterionTypes.AcceptQueries{CPE: []int{}},
+						Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{}, VersionUnconfirmed: []int{}}},
 					},
 					{
 						Criterion: criterionTypes.Criterion{
@@ -788,7 +788,7 @@ func Test_replaceIndexes(t *testing.T) {
 								CPE: "cpe:2.3:a:vendor:pkg1:*:*:*:*:*:*:*:*",
 							},
 						},
-						Accepts: criterionTypes.AcceptQueries{CPE: []int{1}},
+						Accepts: criterionTypes.AcceptQueries{CPE: criterionTypes.CPEAccepts{Exact: []int{1}, VersionUnconfirmed: []int{0}}},
 					},
 				},
 			},


### PR DESCRIPTION
## What

Adopt the categorized `AcceptQueries.CPE` (`CPEAccepts{Exact, VersionUnconfirmed}`) introduced in vuls-data-update. `replaceIndexes` now remaps **both** match-quality index slices from request-local back to original scan indices (mirroring the `Version` handling).

## Why

CPE match quality (exact vs version-unconfirmed) is now determined in `cpecriterion.Match` and carried through `FilteredCriterion.Accepts.CPE`. This is the consumer-side update so the detect pipeline preserves the per-quality indices.

## How

- `pkg/detect/util.replaceIndexes`: remap `cn.Accepts.CPE.Exact` and `cn.Accepts.CPE.VersionUnconfirmed`.
- Tests (`Test_replaceIndexes`, cpe `TestDetect`) updated to the categorized shape.

## Testing

`go test ./pkg/detect/...` green (via go.work against local vuls-data-update).

## Coordination (dependency order)

MaineK00n/vuls-data-update#850 is **merged**; go.mod is bumped to it (bfedbc24). Downstream: future-architect/vuls#2575 (bump its go.mod after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

